### PR TITLE
Support scanning all types of 1D barcodes

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -170,7 +170,7 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
             public void onClick(View v)
             {
                 IntentIntegrator integrator = new IntentIntegrator(LoyaltyCardViewActivity.this);
-                integrator.setDesiredBarcodeFormats(IntentIntegrator.PRODUCT_CODE_TYPES);
+                integrator.setDesiredBarcodeFormats(IntentIntegrator.ONE_D_CODE_TYPES);
 
                 String prompt = getResources().getString(R.string.scanCardBarcode);
                 integrator.setPrompt(prompt);


### PR DESCRIPTION
There are loyalty cards which are not product codes but are 1D
barcodes. Enabling support for all types of 1D barcodes to
enable more types of loyalty cards.