### PR TITLE
update zxing-android-embedded to latest release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:design:23.1.1'
-    compile 'com.journeyapps:zxing-android-embedded:3.0.1@aar'
+    compile 'com.journeyapps:zxing-android-embedded:3.2.0@aar'
     compile 'com.google.zxing:core:3.2.1'
     testCompile 'junit:junit:4.12'
     testCompile "org.robolectric:robolectric:3.0"


### PR DESCRIPTION
tThere was an issue with requesting camera permission
for Android 6 which was resolved in release 3.2.0.

This attempts to resolve:
https://github.com/brarcher/loyalty-card-locker/issues/12