### PR TITLE
Update Italian translation for note

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -25,5 +25,5 @@
     <string name="noCardIdError">Nessun codice carta inserito</string>
 
     <string name="cardIdFormat">%1$s: %2$s</string>
-    <string name="note">Nota</string>
+    <string name="note">Note</string>
 </resources>


### PR DESCRIPTION
Airon90 mentioned that although "Nota" is Italian for "Note", it would be better to use the plural
form "Note" here.

https://github.com/brarcher/loyalty-card-locker/pull/29