### PR TITLE
Reduce min SDK version to 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ android:
     # Additional components
     - extra
 
-    # Specify at least one system image,
-    # if you need to run emulator(s) during your tests
-    - sys-img-x86-android-17
-
 script: ./gradlew build lint findbugs test
 
 after_failure:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "protect.card_locker"
-        minSdkVersion 17
+        minSdkVersion 11
         targetSdkVersion 23
         versionCode 5
         versionName "0.5"


### PR DESCRIPTION
The selection of SDK 17 was arbitrarily based on the version
available on my device at the time. As no APIs are being used
at that level, a lower SDK version can be targeted.

According to the current distribution of Android device versions,
99.9% of devices are at SDK 11+. Changing to this for the min SDK
for now.
