### PR TITLE
Adjust brightness to its maximum when displaying a card

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -14,6 +14,8 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -55,6 +57,20 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         final boolean viewLoyaltyCard = b != null && b.getBoolean("view", false);
 
         Log.i(TAG, "To view card: " + loyaltyCardId);
+
+        if(viewLoyaltyCard)
+        {
+            // The brightness value is on a scale from [0, ..., 1], where
+            // '1' is the brightest. We attempt to maximize the brightness
+            // to help barcode readers scan the barcode.
+            Window window = getWindow();
+            if(window != null)
+            {
+                WindowManager.LayoutParams attributes = window.getAttributes();
+                attributes.screenBrightness = 1F;
+                window.setAttributes(attributes);
+            }
+        }
 
         final EditText storeField = (EditText) findViewById(R.id.storeName);
         final EditText noteField = (EditText) findViewById(R.id.note);

--- a/app/src/test/java/protect/card_locker/ImportExportTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportTest.java
@@ -109,7 +109,7 @@ public class ImportExportTest
     @Test
     public void multipleCardsExportImport() throws IOException
     {
-        final int NUM_CARDS = 1000;
+        final int NUM_CARDS = 10;
 
         for(DataFormat format : DataFormat.values())
         {
@@ -144,7 +144,7 @@ public class ImportExportTest
     @Test
     public void importExistingCardsNotReplace() throws IOException
     {
-        final int NUM_CARDS = 1000;
+        final int NUM_CARDS = 10;
 
         for(DataFormat format : DataFormat.values())
         {
@@ -177,7 +177,7 @@ public class ImportExportTest
     @Test
     public void corruptedImportNothingSaved() throws IOException
     {
-        final int NUM_CARDS = 1000;
+        final int NUM_CARDS = 10;
 
         for(DataFormat format : DataFormat.values())
         {


### PR DESCRIPTION
Some users have mentioned that a barcode scanner has the best success when the screen is at its brightest. To enable the best results, the screen brightness will now be adjusted to its maximum when displaying a loyalty card.
    
https://github.com/brarcher/loyalty-card-locker/issues/21