### PR TITLE
Small update to italian translation 

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -12,7 +12,7 @@
 
     <string name="cancel">Annulla</string>
     <string name="save">Salva</string>
-    <string name="capture">Scansione codice</string>
+    <string name="capture">Scansione carta</string>
     <string name="edit">Modifica</string>
     <string name="delete">Elimina</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -12,7 +12,7 @@
 
     <string name="cancel">Annulla</string>
     <string name="save">Salva</string>
-    <string name="capture">Salva tessera</string>
+    <string name="capture">Scansione codice</string>
     <string name="edit">Modifica</string>
     <string name="delete">Elimina</string>
 


### PR DESCRIPTION
"Salva tessera" in Italian can be translated to "Save card" in English, It is:

-  associated to a button that start barcode scanning

- on the same screen of another button "Salva" in Itlaian (Save in  English)

I propose a less confusing translation: "scansione carta", that in English is "Card scan"