### PR TITLE
Change default import/export file name

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -36,7 +36,7 @@ public class ImportExportActivity extends AppCompatActivity
     private ImportExportTask importExporter;
 
     private final File sdcardDir = Environment.getExternalStorageDirectory();
-    private final File exportFile = new File(sdcardDir, "LoyaltyCardLocker.csv");
+    private final File exportFile = new File(sdcardDir, "LoyaltyCardKeychain.csv");
 
     @Override
     protected void onCreate(Bundle savedInstanceState)


### PR DESCRIPTION
The application is now "Loyalty Card Keychain", but "Locker"
still appears in the application's default import/export
file. Updating the file to match the new name of the application.