### PR TITLE
Remove downloading extras during travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ android:
     # The SDK version used to compile your project
     - android-23
 
-    # Additional components
-    - extra
-
 script: ./gradlew build lint findbugs test
 
 after_failure:


### PR DESCRIPTION
The application does not use google play and other extra libraries,
so downloading them during the build should be unnecessary.