### PR TITLE
Pre-populate Barcode Selector

### DIFF
--- a/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
+++ b/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
@@ -124,6 +124,14 @@ public class BarcodeSelectorActivity extends AppCompatActivity
                 // Noting to do
             }
         });
+
+        final Bundle b = getIntent().getExtras();
+        final String initialCardId = b != null ? b.getString("initialCardId") : null;
+
+        if(initialCardId != null)
+        {
+            cardId.setText(initialCardId);
+        }
     }
 
     private void createBarcodeOption(final ImageView image, final String formatType, final String cardId)

--- a/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
+++ b/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
@@ -144,7 +144,6 @@ public class BarcodeSelectorActivity extends AppCompatActivity
         }
 
         image.setImageBitmap(null);
-        image.setVisibility(View.GONE);
         image.setOnClickListener(new View.OnClickListener()
         {
             @Override

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -222,6 +222,15 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
             public void onClick(View v)
             {
                 Intent i = new Intent(getApplicationContext(), BarcodeSelectorActivity.class);
+
+                String cardId = cardIdFieldEdit.getText().toString();
+                if(cardId.length() > 0)
+                {
+                    final Bundle b = new Bundle();
+                    b.putString("initialCardId", cardId);
+                    i.putExtras(b);
+                }
+
                 startActivityForResult(i, SELECT_BARCODE_REQUEST);
             }
         });


### PR DESCRIPTION
If a user is attempting to update a card id of an existing card, before when the Enter Card button was selected the barcode selector view would be empty. To be more useful, the view will now be pre-populated with the existing card id.