### PR TITLE
Limit width of barcodes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:design:23.1.1'
-    compile 'com.journeyapps:zxing-android-embedded:3.2.0@aar'
-    compile 'com.google.zxing:core:3.2.1'
+    compile 'com.journeyapps:zxing-android-embedded:3.5.0@aar'
+    compile 'com.google.zxing:core:3.3.0'
     compile 'org.apache.commons:commons-csv:1.2'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     testCompile 'junit:junit:4.12'

--- a/app/src/main/java/protect/card_locker/BarcodeImageWriterTask.java
+++ b/app/src/main/java/protect/card_locker/BarcodeImageWriterTask.java
@@ -21,6 +21,7 @@ import java.lang.ref.WeakReference;
 class BarcodeImageWriterTask extends AsyncTask<Void, Void, Bitmap>
 {
     private static final String TAG = "LoyaltyCardLocker";
+    private static final int MAX_WIDTH = 600;
 
     private final WeakReference<ImageView> imageViewReference;
     private final String cardId;
@@ -37,7 +38,10 @@ class BarcodeImageWriterTask extends AsyncTask<Void, Void, Bitmap>
         cardId = cardIdString;
         format = barcodeFormat;
         imageHeight = imageView.getHeight();
-        imageWidth = imageView.getWidth();
+
+        // No matter how long the window is, there is only so much space
+        // needed for the barcode. Put a limit on it to reduce memory usage
+        imageWidth = Math.min(imageView.getWidth(), MAX_WIDTH);
     }
 
     public Bitmap doInBackground(Void... params)


### PR DESCRIPTION
To reduce the amount of memory used in generating barcodes, limit
the width of the barcodes to no more than 3x the height.
This should be plenty sufficient to generate a usable barcode.

On devices with a really long width generating a barcode of 200x2560
is not useful and can result in an OutOfMemoryError.

https://github.com/brarcher/loyalty-card-locker/issues/99