### PR TITLE
handle orientation and resize config change for IntroActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
         <activity
             android:name=".IntroActivity"
             android:label=""
+            android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.NoActionBar"/>
     </application>
 


### PR DESCRIPTION
If orientation and resize are not handled if the screen is
rotate or resized the IntroSlide fragment loses its layout,
and when it tries inflates the layout it fails to do so.