### PR TITLE
Verify card exists before displaying it

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -79,6 +79,10 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         updateLoyaltyCard = b != null && b.getBoolean("update", false);
         viewLoyaltyCard = b != null && b.getBoolean("view", false);
 
+        Log.d(TAG, "View activity: id=" + loyaltyCardId
+                + ", updateLoyaltyCard=" + Boolean.toString(updateLoyaltyCard)
+                + ", viewLoyaltyCard=" + Boolean.toString(viewLoyaltyCard));
+
         db = new DBHelper(this);
     }
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -25,6 +25,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.integration.android.IntentIntegrator;
@@ -125,6 +126,13 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         if(updateLoyaltyCard || viewLoyaltyCard)
         {
             final LoyaltyCard loyaltyCard = db.getLoyaltyCard(loyaltyCardId);
+            if(loyaltyCard == null)
+            {
+                Log.w(TAG, "Could not lookup loyalty card " + loyaltyCardId);
+                Toast.makeText(this, R.string.noCardExistsError, Toast.LENGTH_LONG).show();
+                finish();
+                return;
+            }
 
             if(storeFieldEdit.getText().length() == 0)
             {

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -35,6 +35,7 @@
 
     <string name="noStoreError">Nebyl zadán Obchod</string>
     <string name="noCardIdError">Nebylo zadáno ID karty</string>
+    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
 
     <string name="cardIdFormat">%1$s: %2$s</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -25,6 +25,7 @@
     <string name="importName">Import</string>
     <string name="importedFrom">Importiert von: %1$s</string>
     <string name="noCardIdError">Keine Kartennummer angegeben</string>
+    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
     <string name="noExternalStoragePermissionError">Ohne die Berechtigung für den externen Speicher kann kein Import oder Export erfolgen.</string>
     <string name="noGiftCards">Sie haben noch keine Kundenkarte angelegt. Über den "+" Button oben rechts, können welche angelegt werden.\n\nDiese App ermöglicht es, Kundenkarten immer mit zu führen.</string>
     <string name="cancel">Abbrechen</string>
@@ -37,7 +38,7 @@
     <!-- NEEDS TRANSLATED --><string name="unlockScreen">Unblock Rotation</string>
     <string name="delete">Löschen</string>
     <string name="deleteConfirmation">Bitte bestätigen Sie, dass diese Karte gelöscht werden soll.</string>
-    <string name="deleteTitle">Lösche die Kundenkarte</string>
+    <string name="deleteTitle">Lösche die Kundenkarte</string><!-- NEEDS TRANSLATED -->
     <string name="edit">Bearbeiten</string>
     <string name="editCardTitle">Kundenkarte bearbeiten</string>
     <string name="enterCard">Karte einfügen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -35,6 +35,7 @@
 
     <string name="noStoreError">Aucun nom n\'a été saisi</string>
     <string name="noCardIdError">Aucun numéro n\'a été saisi</string>
+    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
 
     <string name="cardIdFormat">%1$s: %2$s</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -25,6 +25,7 @@
 
     <string name="noStoreError">Nessun negozio inserito</string>
     <string name="noCardIdError">Nessun codice carta inserito</string>
+    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
 
     <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="note">Note</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -35,6 +35,7 @@
 
     <string name="noStoreError">Parduotuvė neįvesta</string>
     <string name="noCardIdError">Neįvestas kortelės ID</string>
+    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
 
     <string name="cardIdFormat">%1$s: %2$s</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -25,6 +25,7 @@
 
     <string name="noStoreError">Geen winkel toegevoegd</string>
     <string name="noCardIdError">Geen kaart-ID toegevoegd</string>
+    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
 
     <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="note">Notitie</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
 
     <string name="noStoreError">No Store entered</string>
     <string name="noCardIdError">No Card ID entered</string>
+    <string name="noCardExistsError">Could not lookup loyalty card</string>
 
     <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="storeNameAndNoteFormat" translatable="false">%1$s - %2$s</string>

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -439,4 +439,24 @@ public class LoyaltyCardViewActivityTest
         assertEquals("Block Rotation", menu.findItem(R.id.action_lock_unlock).getTitle().toString());
         assertEquals("Edit", menu.findItem(R.id.action_edit).getTitle().toString());
     }
+
+    @Test
+    public void startWithMissingLoyaltyCard() throws IOException
+    {
+        ActivityController activityController = createActivityWithLoyaltyCard(true);
+        Activity activity = (Activity)activityController.get();
+
+        activityController.start();
+        activityController.visible();
+        activityController.resume();
+
+        // The activity should find that the card is missing and shut down
+
+        assertTrue(activity.isFinishing());
+
+        // Make sure the activity can close down
+        activityController.pause();
+        activityController.stop();
+        activityController.destroy();
+    }
 }


### PR DESCRIPTION
At least one user in production has hit a case where the app was requested to display or update an existing id, but the id could not be found.

This adds a check that the card is found, and if it is not a message is displayed and bails out gracefully.