### PR TITLE
Remove missing translations stubbed to English

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ android {
         disable "GoogleAppIndexingWarning"
         disable "ButtonStyle"
         disable "AlwaysShowAction"
+        disable "MissingTranslation"
     }
 
     // This is for Robolectric support for SDK 23

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -15,12 +15,11 @@
     <string name="save">Uložit</string>
     <string name="capture">Naskenovat kartu</string>
     <string name="enterCard">Vložit vlastnoručně</string>
-    <!-- NEEDS TRANSLATED --><string name="editCard">Edit Card</string>
+
     <string name="edit">Editovat</string>
     <string name="delete">Smazat</string>
     <string name="confirm">Potvrdit</string>
-    <!-- NEEDS TRANSLATED --><string name="lockScreen">Block Rotation</string>
-    <!-- NEEDS TRANSLATED --><string name="unlockScreen">Unblock Rotation</string>
+
     <string name="deleteTitle">Odstzranit věrnostní kartu</string>
     <string name="deleteConfirmation">Opravdu chcete smazat tuto věrnostní kartu?</string>
     <string name="ok">Ano</string>
@@ -35,7 +34,7 @@
 
     <string name="noStoreError">Nebyl zadán Obchod</string>
     <string name="noCardIdError">Nebylo zadáno ID karty</string>
-    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
+
 
     <string name="cardIdFormat">%1$s: %2$s</string>
 
@@ -58,7 +57,6 @@
     <string name="debug_version_fmt">Verze: <xliff:g id="version">%s</xliff:g></string>
     <string name="app_revision_fmt">Revizní informace: <xliff:g id="app_revision_url">%s</xliff:g></string>
     <string name="app_libraries"><xliff:g id="app_name">%s</xliff:g> používá tyto knihovny třetích stran: <xliff:g id="app_libraries_list">%s</xliff:g></string>
-    <!-- NEEDS TRANSLATED --><string name="app_resources"><xliff:g id="app_name">%s</xliff:g> uses the following third-party resources: <xliff:g id="app_resources_list">%s</xliff:g></string>
 
     <string name="selectBarcodeTitle">Vyberte čárový kód</string>
     <string name="enterBarcodeInstructions">Zadejte hodnotu čárového kódu a potm vyberte kód, který představuje čárový kód, který je na kartě.</string>
@@ -81,17 +79,4 @@
     <string name="importOptionFixedButton">Použít složku exportu</string>
     <string name="sendLabel">Odeslat&#8230;</string>
 
-    <!-- NEEDS TRANSLATED --><string name="startIntro">Start Intro</string>
-    <!-- NEEDS TRANSLATED --><string name="intro1Title">Welcome to Loyalty Card Keychain\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro1Description">Manage your barcode-based store/loyalty cards on your phone!\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro2Title">Adding Cards\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro2Description">Add a new card by touching the plus from the card list.\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro3Title">Adding Cards\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro3Description">To add the barcode, either capture with the camera or type in manually.\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro4Title">Show Card\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro4Description">To display a card, click on the store name from the main screen\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro5Title">Backup\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro5Description">The cards can be backed-up. To export or import card data touch Import/Export in the menu on the main page.\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro6Title">Feedback\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro6Description">This app is free, ad-free, and open source. See details by touching About in the menu on the main page.\n\nPlease leave feedback in the app store! (:</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -25,7 +25,7 @@
     <string name="importName">Import</string>
     <string name="importedFrom">Importiert von: %1$s</string>
     <string name="noCardIdError">Keine Kartennummer angegeben</string>
-    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
+
     <string name="noExternalStoragePermissionError">Ohne die Berechtigung für den externen Speicher kann kein Import oder Export erfolgen.</string>
     <string name="noGiftCards">Sie haben noch keine Kundenkarte angelegt. Über den "+" Button oben rechts, können welche angelegt werden.\n\nDiese App ermöglicht es, Kundenkarten immer mit zu führen.</string>
     <string name="cancel">Abbrechen</string>
@@ -34,11 +34,10 @@
     <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="confirm">Bestätigen</string>
     <string name="copy_to_clipboard">Kopiere die Nummer in die Zwischenablage</string>
-    <!-- NEEDS TRANSLATED --><string name="lockScreen">Block Rotation</string>
-    <!-- NEEDS TRANSLATED --><string name="unlockScreen">Unblock Rotation</string>
+
     <string name="delete">Löschen</string>
     <string name="deleteConfirmation">Bitte bestätigen Sie, dass diese Karte gelöscht werden soll.</string>
-    <string name="deleteTitle">Lösche die Kundenkarte</string><!-- NEEDS TRANSLATED -->
+
     <string name="edit">Bearbeiten</string>
     <string name="editCardTitle">Kundenkarte bearbeiten</string>
     <string name="enterCard">Karte einfügen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -18,8 +18,7 @@
     <string name="editCard">Modifier</string>
     <string name="edit">Modifier</string>
     <string name="delete">Supprimer</string>
-    <!-- NEEDS TRANSLATED --><string name="lockScreen">Block Rotation</string>
-    <!-- NEEDS TRANSLATED --><string name="unlockScreen">Unblock Rotation</string>
+
     <string name="confirm">Confirmer</string>
     <string name="deleteTitle">Supprimer la carte de fidélité</string>
     <string name="deleteConfirmation">Confirmez que vous souhaitez supprimer cette carte</string>
@@ -35,7 +34,6 @@
 
     <string name="noStoreError">Aucun nom n\'a été saisi</string>
     <string name="noCardIdError">Aucun numéro n\'a été saisi</string>
-    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
 
     <string name="cardIdFormat">%1$s: %2$s</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -25,7 +25,7 @@
 
     <string name="noStoreError">Nessun negozio inserito</string>
     <string name="noCardIdError">Nessun codice carta inserito</string>
-    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
+
 
     <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="note">Note</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -15,12 +15,11 @@
     <string name="save">Išsaugoti</string>
     <string name="capture">Nufotografuoti kortelę</string>
     <string name="enterCard">Įvesti kortelę</string>
-    <!-- NEEDS TRANSLATED --><string name="editCard">Edit Card</string>
+
     <string name="edit">Redaguoti</string>
     <string name="delete">Ištrinti</string>
     <string name="confirm">Patvirtinti</string>
-    <!-- NEEDS TRANSLATED --><string name="lockScreen">Block Rotation</string>
-    <!-- NEEDS TRANSLATED --><string name="unlockScreen">Unblock Rotation</string>
+
     <string name="deleteTitle">Panaikinti lojalumo kortelę</string>
     <string name="deleteConfirmation">Prašome patvirtinti jog Jūs norite panaikinti šią lojalumo kortelę.</string>
     <string name="ok">Gerai</string>
@@ -35,7 +34,7 @@
 
     <string name="noStoreError">Parduotuvė neįvesta</string>
     <string name="noCardIdError">Neįvestas kortelės ID</string>
-    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
+
 
     <string name="cardIdFormat">%1$s: %2$s</string>
 
@@ -58,41 +57,10 @@
     <string name="debug_version_fmt">Versija: <xliff:g id="version">%s</xliff:g></string>
     <string name="app_revision_fmt">Revizijos informacija: <xliff:g id="app_revision_url">%s</xliff:g></string>
     <string name="app_libraries"><xliff:g id="app_name">%s</xliff:g> naudoja šias trečiosios šalies bibliotekas: <xliff:g id="app_libraries_list">%s</xliff:g></string>
-    <!-- NEEDS TRANSLATED --><string name="app_resources"><xliff:g id="app_name">%s</xliff:g> uses the following third-party resources: <xliff:g id="app_resources_list">%s</xliff:g></string>
 
     <string name="selectBarcodeTitle">Pasirinkite brūkšninį kodą</string>
     <string name="enterBarcodeInstructions">Enter the barcode value then select the image which represents the barcode you want to use</string>
 
     <string name="copy_to_clipboard_toast">Kortelės ID nukopijuota į iškarpinę</string>
     
-    <!-- needs translated --><string name="importExportHelp">Backed up data can allow you to move your cards to another device.</string>
-    <!-- needs translated --><string name="importSuccessfulTitle">Import successful</string>
-    <!-- needs translated --><string name="importFailedTitle">Import failed</string>
-    <!-- needs translated --><string name="exportSuccessfulTitle">Export successful</string>
-    <!-- needs translated --><string name="exportFailedTitle">Export failed</string>
-    <!-- needs translated --><string name="exportOptionExplanation">Data is written to the top directory in external storage.</string>
-    <!-- needs translated --><string name="importOptionFilesystemTitle">Import from filesystem</string>
-    <!-- needs translated --><string name="importOptionFilesystemExplanation">Choose a specific file from the filesystem.</string>
-    <!-- needs translated --><string name="importOptionFilesystemButton">From filesystem</string>
-    <!-- needs translated --><string name="importOptionApplicationTitle">Use external application</string>
-    <!-- needs translated --><string name="importOptionApplicationExplanation">Use an external application like Dropbox, Google Drive, or your favorite file manager to open a file.</string>
-    <!-- needs translated --><string name="importOptionApplicationButton">Use external application</string>
-    <!-- needs translated --><string name="importOptionFixedTitle">Import from export location</string>
-    <!-- needs translated --><string name="importOptionFixedExplanation">Import from the same location on the filesystem that is written to on export.</string>
-    <!-- needs translated --><string name="importOptionFixedButton">Use export location</string>
-    <!-- needs translated --> <string name="sendLabel">Send&#8230;</string>
-
-    <!-- NEEDS TRANSLATED --><string name="startIntro">Start Intro</string>
-    <!-- NEEDS TRANSLATED --><string name="intro1Title">Welcome to Loyalty Card Keychain\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro1Description">Manage your barcode-based store/loyalty cards on your phone!\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro2Title">Adding Cards\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro2Description">Add a new card by touching the plus from the card list.\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro3Title">Adding Cards\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro3Description">To add the barcode, either capture with the camera or type in manually.\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro4Title">Show Card\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro4Description">To display a card, click on the store name from the main screen\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro5Title">Backup\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro5Description">The cards can be backed-up. To export or import card data touch Import/Export in the menu on the main page.\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro6Title">Feedback\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro6Description">This app is free, ad-free, and open source. See details by touching About in the menu on the main page.\n\nPlease leave feedback in the app store! (:</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -25,7 +25,6 @@
 
     <string name="noStoreError">Geen winkel toegevoegd</string>
     <string name="noCardIdError">Geen kaart-ID toegevoegd</string>
-    <!-- NEEDS TRANSLATED --><string name="noCardExistsError">Could not lookup loyalty card</string>
 
     <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="note">Notitie</string>
@@ -48,10 +47,10 @@
     <string name="debug_version_fmt">Versie: <xliff:g id="version">%s</xliff:g></string>
     <string name="app_revision_fmt">Revisieïnformatie: <xliff:g id="app_revision_url">%s</xliff:g></string>
     <string name="app_libraries"><xliff:g id="app_name">%s</xliff:g> gebruikt de volgende bibliotheken van derden: <xliff:g id="app_libraries_list">%s</xliff:g></string>
-    <!-- NEEDS TRANSLATED --><string name="app_resources"><xliff:g id="app_name">%s</xliff:g> uses the following third-party resources: <xliff:g id="app_resources_list">%s</xliff:g></string>
+
     <string name="ok">Oké</string>
     <string name="enterCard">Voer kaart in</string>
-    <!-- NEEDS TRANSLATED --><string name="editCard">Edit Card</string>
+
     <string name="selectBarcodeTitle">Selecteer barcode</string>
     <string name="enterBarcodeInstructions">Voer de waarde van de barcode in en kies daarna de afbeelding die de barcode die je wil gebruiken representeert</string>
     <string name="copy_to_clipboard">Kopieer het ID naar het klembord</string>
@@ -59,8 +58,7 @@
     <string name="confirm">Bevestig</string>
     <string name="deleteConfirmation">Bevestig deze kaart te verwijderen.</string>
     <string name="deleteTitle">Verwijder kaart</string>
-    <!-- NEEDS TRANSLATED --><string name="lockScreen">Block Rotation</string>
-    <!-- NEEDS TRANSLATED --><string name="unlockScreen">Unblock Rotation</string>
+
     <string name="importExportHelp">Data die is geback-upt maakt het mogelijk om je klantenkaarten naar een ander apparaat te verplaatsen.</string>
     <string name="importSuccessfulTitle">Importeren succesvol</string>
     <string name="importFailedTitle">Importeren mislukte</string>
@@ -78,17 +76,4 @@
     <string name="importOptionFixedButton">gebruik exporteerlocaite</string>
     <string name="sendLabel">Verzend&#8230;</string>
 
-    <!-- NEEDS TRANSLATED --><string name="startIntro">Start Intro</string>
-    <!-- NEEDS TRANSLATED --><string name="intro1Title">Welcome to Loyalty Card Keychain\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro1Description">Manage your barcode-based store/loyalty cards on your phone!\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro2Title">Adding Cards\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro2Description">Add a new card by touching the plus from the card list.\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro3Title">Adding Cards\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro3Description">To add the barcode, either capture with the camera or type in manually.\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro4Title">Show Card\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro4Description">To display a card, click on the store name from the main screen\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro5Title">Backup\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro5Description">The cards can be backed-up. To export or import card data touch Import/Export in the menu on the main page.\n\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro6Title">Feedback\n</string>
-    <!-- NEEDS TRANSLATED --><string name="intro6Description">This app is free, ad-free, and open source. See details by touching About in the menu on the main page.\n\nPlease leave feedback in the app store! (:</string>
 </resources>


### PR DESCRIPTION
By request, a project on Transifex was created to better
manage translations. To make things less confusing, instead
of using the MissingTranslations lint error, and thus needing
to add stub translations, the progress of translations is now
handled on Transifex.

transifex.com/na-243/loyalty-card-locker/