### PR TITLE
Only let one card viewing activity exist at a time

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
             android:name=".LoyaltyCardViewActivity"
             android:theme="@style/AppTheme.NoActionBar"
             android:configChanges="orientation|screenSize"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="stateHidden"/>
         <activity
             android:name=".BarcodeSelectorActivity"


### PR DESCRIPTION
Now that there are shortcuts which can launch card viewing activities
directly, if a user does not back out of the activity then there will
be a pile up of activities over time. To prevent this, only let
one such view activity exist at a time.