### PR TITLE
Remove file:// Uri from backup file picker

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -85,7 +85,6 @@ public class ImportExportActivity extends AppCompatActivity
 
         // Check that there is an activity that can bring up a file chooser
         final Intent intentPickAction = new Intent(Intent.ACTION_PICK);
-        intentPickAction.setData(Uri.parse("file://"));
 
         Button importFilesystem = (Button) findViewById(R.id.importOptionFilesystemButton);
         importFilesystem.setOnClickListener(new View.OnClickListener()

--- a/app/src/test/java/protect/card_locker/ImportExportActivityTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportActivityTest.java
@@ -40,10 +40,6 @@ public class ImportExportActivityTest
         info.activityInfo.exported = true;
 
         Intent intent = new Intent(handler);
-        if(handler.equals(Intent.ACTION_PICK))
-        {
-            intent.setData(Uri.parse("file://"));
-        }
 
         if(handler.equals(Intent.ACTION_GET_CONTENT))
         {


### PR DESCRIPTION
On Android SDK 24+ exposing a file Uri causes a failure.
Picking a file from a file chooser using data of a file://
Uri also hits this. As this is not necessary, removing the
Uri.