### PR TITLE
Fix crash on some corruption when importing CSV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
 - echo y | android update sdk -u -a -t tools
 - echo y | android update sdk -u -a -t platform-tools
 - echo y | android update sdk -u -a -t build-tools-26.0.2
-- echo y | android update sdk -u -a -t android-27
+- yes | sdkmanager "platforms;android-27"
 - echo y | android update sdk -u -a -t extra-google-m2repository
 - echo y | android update sdk -u -a -t extra-android-m2repository
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compile 'com.android.support:design:27.0.2'
     compile 'com.journeyapps:zxing-android-embedded:3.5.0@aar'
     compile 'com.google.zxing:core:3.3.0'
-    compile 'org.apache.commons:commons-csv:1.2'
+    compile 'org.apache.commons:commons-csv:1.5'
     compile group: 'com.google.guava', name: 'guava', version: '20.0'
     compile 'com.github.apl-devs:appintro:v4.2.0'
     testCompile 'junit:junit:4.12'

--- a/app/src/main/java/protect/card_locker/CsvDatabaseImporter.java
+++ b/app/src/main/java/protect/card_locker/CsvDatabaseImporter.java
@@ -40,7 +40,7 @@ public class CsvDatabaseImporter implements DatabaseImporter
             parser.close();
             database.setTransactionSuccessful();
         }
-        catch(IllegalArgumentException e)
+        catch(IllegalArgumentException|IllegalStateException e)
         {
             throw new FormatException("Issue parsing CSV data", e);
         }

--- a/app/src/test/java/protect/card_locker/ImportExportTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportTest.java
@@ -198,7 +198,11 @@ public class ImportExportTest
 
             clearDatabase();
 
-            String corruptEntry = "ThisStringIsLikelyNotPartOfAnyFormat";
+            // commons-csv would throw a RuntimeException if an entry was quotes but had
+            // content after. For example:
+            //   abc,def,""abc,abc
+            //             ^ after the quote there should only be a , \n or EOF
+            String corruptEntry = "ThisStringIsLikelyNotPartOfAnyFormat,\"\"a";
 
             ByteArrayInputStream inData = new ByteArrayInputStream((outData.toString() + corruptEntry).getBytes());
             InputStreamReader inStream = new InputStreamReader(inData);


### PR DESCRIPTION
Commons-CSV would throw a RuntimeException in some cases of
bad CSV input. This was later changed to throwing an
IllegalStateException. Updating to v1.5 to pick-up the change.