### PR TITLE
Do not bother to show file name after an import

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -235,33 +235,6 @@ public class ImportExportActivity extends AppCompatActivity
         return super.onOptionsItemSelected(item);
     }
 
-    private String fileNameFromUri(Uri uri)
-    {
-        if("file".equals(uri.getScheme()))
-        {
-            return uri.getPath();
-        }
-
-        Cursor returnCursor =
-                getContentResolver().query(uri, null, null, null, null);
-        if(returnCursor == null)
-        {
-            return null;
-        }
-
-        int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
-        if(returnCursor.moveToFirst() == false)
-        {
-            returnCursor.close();
-            return null;
-        }
-
-        String name = returnCursor.getString(nameIndex);
-        returnCursor.close();
-
-        return name;
-    }
-
     private void onImportComplete(boolean success, Uri path)
     {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
@@ -275,19 +248,6 @@ public class ImportExportActivity extends AppCompatActivity
             builder.setTitle(R.string.importFailedTitle);
         }
 
-        int messageId = success ? R.string.importedFrom : R.string.importFailed;
-
-        final String template = getResources().getString(messageId);
-
-        // Get the filename of the file being imported
-        String filename = fileNameFromUri(path);
-        if(filename == null)
-        {
-            filename = "(unknown)";
-        }
-
-        final String message = String.format(template, filename);
-        builder.setMessage(message);
         builder.setNeutralButton(R.string.ok, new DialogInterface.OnClickListener()
         {
             @Override


### PR DESCRIPTION
It was observed by one user that the Uri to filename lookup
failed with an IllegalStateException. The code which
converts a Uri to a file path may not be that great,
especially now that the app is expected to not receive
file Uris. Instead of determining the best way to lookup
the file names, as it is not that important it will be
removed.