### PR TITLE
Reduce space used in header for card view

### DIFF
--- a/app/src/main/res/layout/loyalty_card_view_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_view_layout.xml
@@ -100,7 +100,7 @@
         android:clipChildren="false"
         android:clipToPadding="false"
         android:layout_width="fill_parent"
-        android:layout_height="224.0dip"
+        android:layout_height="wrap_content"
         android:weightSum="1.0"
         android:fitsSystemWindows="true">
         <android.support.design.widget.CollapsingToolbarLayout
@@ -126,6 +126,7 @@
                 android:textAlignment="center"
                 android:layout_gravity="center"
                 android:layout_marginTop="?actionBarSize"
+                android:layout_marginBottom="?actionBarSize"
                 app:layout_collapseMode="parallax"
                 android:fitsSystemWindows="true"/>
             <android.support.v7.widget.Toolbar


### PR DESCRIPTION
The landscape view left little room for the barcode and card ID
because the header took up a lot of space. Further, on smaller
phones it would take up a large portion of the screen.

This change reduces the header from 224dp to two action bar sizes
plus the size of the textview for the store name.