### PR TITLE
Catch case where barcode rendering runs into an OOM

### DIFF
--- a/app/src/main/java/protect/card_locker/BarcodeImageWriterTask.java
+++ b/app/src/main/java/protect/card_locker/BarcodeImageWriterTask.java
@@ -149,6 +149,12 @@ class BarcodeImageWriterTask extends AsyncTask<Void, Void, Bitmap>
         {
             Log.e(TAG, "Failed to generate barcode of type " + format + ": " + cardId, e);
         }
+        catch(OutOfMemoryError e)
+        {
+            Log.w(TAG, "Insufficient memory to render barcode, "
+                + imageWidth + "x" + imageHeight + ", " + format.name()
+                + ", length=" + cardId.length(), e);
+        }
 
         return null;
     }


### PR DESCRIPTION
There are still cases where the barcode could not be rendered
because the process runs out of its memory limit. To avoid
a crash, catch the failure and log it. The barcode will
not be displayed, but at least the app will not crash.