### PR TITLE
Remove unnecessary apache legacy usage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,9 +37,6 @@ android {
             includeAndroidResources = true
         }
     }
-
-    // This is for Robolectric support for SDK 23
-    useLibrary 'org.apache.http.legacy'
 }
 
 dependencies {


### PR DESCRIPTION
The version of robolectric used no longer requires using the org.apache.http.legacy library.