### PR TITLE
Configure brightening screen when display a barcode

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -96,7 +96,7 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         // '1' is the brightest. We attempt to maximize the brightness
         // to help barcode readers scan the barcode.
         Window window = getWindow();
-        if(window != null)
+        if(window != null && settings.useMaxBrightnessDisplayingBarcode())
         {
             WindowManager.LayoutParams attributes = window.getAttributes();
             attributes.screenBrightness = 1F;

--- a/app/src/main/java/protect/card_locker/preferences/Settings.java
+++ b/app/src/main/java/protect/card_locker/preferences/Settings.java
@@ -34,6 +34,11 @@ public class Settings
         return settings.getInt(getResString(keyId), getResInt(defaultId));
     }
 
+    private boolean getBoolean(@StringRes int keyId, boolean defaultValue)
+    {
+        return settings.getBoolean(getResString(keyId), defaultValue);
+    }
+
     public int getCardTitleListFontSize()
     {
         return getInt(R.string.settings_key_card_title_list_font_size, R.integer.settings_card_title_list_font_size_sp);
@@ -57,5 +62,10 @@ public class Settings
     public int getCardNoteFontSize()
     {
         return getInt(R.string.settings_key_card_note_font_size, R.integer.settings_card_note_font_size_sp);
+    }
+
+    public boolean useMaxBrightnessDisplayingBarcode()
+    {
+        return getBoolean(R.string.settings_key_display_barcode_max_brightness, true);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,5 +119,6 @@
     <string name="settings_key_card_id_font_size" translatable="false">pref_card_id_font_size_sp</string>
     <string name="settings_card_note_font_size">Card note font size</string>
     <string name="settings_key_card_note_font_size" translatable="false">pref_card_note_font_size_sp</string>
-
+    <string name="settings_display_barcode_max_brightness">Brighten barcode view</string>
+    <string name="settings_key_display_barcode_max_brightness" translatable="false">pref_display_card_max_brightness</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -40,6 +40,10 @@
             android:defaultValue="@integer/settings_card_note_font_size_sp"
             app:vnt_maxValue="@integer/settings_card_note_max_font_size_sp"
             app:vnt_minValue="@integer/settings_card_note_min_font_size_sp" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="@string/settings_key_display_barcode_max_brightness"
+            android:title="@string/settings_display_barcode_max_brightness"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
When a barcode is displayed the screen's brightness is set to
the maximum, in an attempt to provide the best chance for a barcode
scanner to capture the barcode. However, it may not always
be desired to increase the brightness, for example when using
the app in low light.

This change adds a setting to control the screen brightening
behavior when a barcode is viewed.

https://github.com/brarcher/loyalty-card-locker/issues/218