### PR TITLE
Sort card list case insensitive

### DIFF
--- a/app/src/main/java/protect/card_locker/DBHelper.java
+++ b/app/src/main/java/protect/card_locker/DBHelper.java
@@ -148,7 +148,7 @@ public class DBHelper extends SQLiteOpenHelper
     {
         SQLiteDatabase db = getReadableDatabase();
         Cursor res =  db.rawQuery("select * from " + LoyaltyCardDbIds.TABLE +
-                " ORDER BY " + LoyaltyCardDbIds.STORE, null);
+                " ORDER BY " + LoyaltyCardDbIds.STORE + " COLLATE NOCASE ASC", null);
         return res;
     }
 


### PR DESCRIPTION
Previously the upper case starting names all came before the lower case names. With this change they will be intermingled, ignoring the case.