### PR TITLE
Add option to lock orientation state

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -449,14 +449,6 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
             format = result.getFormatName();
         }
 
-        if(requestCode == SELECT_BARCODE_REQUEST && resultCode == Activity.RESULT_OK)
-        {
-            Log.i(TAG, "Received barcode information from capture");
-
-            contents = intent.getStringExtra(BarcodeSelectorActivity.BARCODE_CONTENTS);
-            format = intent.getStringExtra(BarcodeSelectorActivity.BARCODE_FORMAT);
-        }
-
         if(contents != null && contents.isEmpty() == false &&
                 format != null && format.isEmpty() == false)
         {

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -227,20 +227,32 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
             case R.id.action_lock_unlock:
                 if(rotationEnabled)
                 {
-                    item.setIcon(R.drawable.ic_lock_outline_white_24dp);
-                    item.setTitle(R.string.unlockScreen);
-                    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_NOSENSOR);
+                    setOrientatonLock(item, true);
                 }
                 else
                 {
-                    item.setIcon(R.drawable.ic_lock_open_white_24dp);
-                    item.setTitle(R.string.lockScreen);
-                    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
+                    setOrientatonLock(item, false);
                 }
                 rotationEnabled = !rotationEnabled;
                 return true;
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    private void setOrientatonLock(MenuItem item, boolean lock)
+    {
+        if(lock)
+        {
+            item.setIcon(R.drawable.ic_lock_outline_white_24dp);
+            item.setTitle(R.string.unlockScreen);
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_NOSENSOR);
+        }
+        else
+        {
+            item.setIcon(R.drawable.ic_lock_open_white_24dp);
+            item.setTitle(R.string.lockScreen);
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
+        }
     }
 }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -200,6 +200,12 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
     {
         getMenuInflater().inflate(R.menu.card_view_menu, menu);
 
+        if(settings.getLockBarcodeScreenOrientation())
+        {
+            MenuItem item = menu.findItem(R.id.action_lock_unlock);
+            setOrientatonLock(item, true);
+            item.setVisible(false);
+        }
 
         return super.onCreateOptionsMenu(menu);
     }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -76,6 +76,8 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         storeName = findViewById(R.id.storeName);
         barcodeImage = findViewById(R.id.barcode);
         collapsingToolbarLayout = findViewById(R.id.collapsingToolbarLayout);
+
+        rotationEnabled = true;
     }
 
     @Override
@@ -198,7 +200,6 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
     {
         getMenuInflater().inflate(R.menu.card_view_menu, menu);
 
-        rotationEnabled = true;
 
         return super.onCreateOptionsMenu(menu);
     }

--- a/app/src/main/java/protect/card_locker/preferences/Settings.java
+++ b/app/src/main/java/protect/card_locker/preferences/Settings.java
@@ -68,4 +68,9 @@ public class Settings
     {
         return getBoolean(R.string.settings_key_display_barcode_max_brightness, true);
     }
+
+    public boolean getLockBarcodeScreenOrientation()
+    {
+        return getBoolean(R.string.settings_key_lock_barcode_orientation, false);
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,4 +121,6 @@
     <string name="settings_key_card_note_font_size" translatable="false">pref_card_note_font_size_sp</string>
     <string name="settings_display_barcode_max_brightness">Brighten barcode view</string>
     <string name="settings_key_display_barcode_max_brightness" translatable="false">pref_display_card_max_brightness</string>
+    <string name="settings_lock_barcode_orientation">Lock barcode orientation</string>
+    <string name="settings_key_lock_barcode_orientation" translatable="false">pref_lock_barcode_orientation</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -40,11 +40,16 @@
             android:defaultValue="@integer/settings_card_note_font_size_sp"
             app:vnt_maxValue="@integer/settings_card_note_max_font_size_sp"
             app:vnt_minValue="@integer/settings_card_note_min_font_size_sp" />
+
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/settings_key_display_barcode_max_brightness"
             android:title="@string/settings_display_barcode_max_brightness"/>
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/settings_key_lock_barcode_orientation"
+            android:title="@string/settings_lock_barcode_orientation"/>
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.widget.TextViewCompat;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -565,5 +566,42 @@ public class LoyaltyCardViewActivityTest
 
         shadowOf(activity).clickMenuItem(android.R.id.home);
         assertEquals(true, activity.isFinishing());
+    }
+
+    @Test
+    public void checkScreenOrientationLockSetting()
+    {
+        for(boolean locked : new boolean[] {false, true})
+        {
+            ActivityController activityController = createActivityWithLoyaltyCard(false);
+
+            Activity activity = (Activity)activityController.get();
+            DBHelper db = new DBHelper(activity);
+            db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE);
+
+            SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(activity);
+            settings.edit()
+                    .putBoolean(activity.getResources().getString(R.string.settings_key_lock_barcode_orientation), locked)
+                    .apply();
+
+            activityController.start();
+            activityController.resume();
+            activityController.visible();
+
+            assertEquals(false, activity.isFinishing());
+
+            MenuItem item = shadowOf(activity).getOptionsMenu().findItem(R.id.action_lock_unlock);
+
+            if(locked)
+            {
+                assertEquals(item.isVisible(), false);
+            }
+            else
+            {
+                assertEquals(item.isVisible(), true);
+                String title = item.getTitle().toString();
+                assertEquals(title, activity.getString(R.string.lockScreen));
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds a new option which controls if the screen orientation lock option is displayed or not. If set, the orientation lock is forced and the unlock option is hidden.

This closes https://github.com/brarcher/loyalty-card-locker/issues/265.