### PR TITLE
Allow backups of app data

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:required="false" />
 
     <application
-        android:allowBackup="false"
+        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
Setting the allowBackup option enables the app to participate
in backup and restore infrastructure.

Fixes: https://github.com/brarcher/loyalty-card-locker/issues/236