### PR TITLE
Added option to keep the screen on

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -98,10 +98,22 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         // '1' is the brightest. We attempt to maximize the brightness
         // to help barcode readers scan the barcode.
         Window window = getWindow();
-        if(window != null && settings.useMaxBrightnessDisplayingBarcode())
+        if(window != null)
         {
             WindowManager.LayoutParams attributes = window.getAttributes();
-            attributes.screenBrightness = 1F;
+
+            if (settings.useMaxBrightnessDisplayingBarcode())
+            {
+                attributes.screenBrightness = 1F;
+            }
+
+            if (settings.getKeepScreenOn())
+            {
+                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON|
+                        WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD|
+                        WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
+            }
+
             window.setAttributes(attributes);
         }
 

--- a/app/src/main/java/protect/card_locker/preferences/Settings.java
+++ b/app/src/main/java/protect/card_locker/preferences/Settings.java
@@ -73,4 +73,9 @@ public class Settings
     {
         return getBoolean(R.string.settings_key_lock_barcode_orientation, false);
     }
+
+    public boolean getKeepScreenOn()
+    {
+        return getBoolean(R.string.settings_key_keep_screen_on, false);
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,4 +123,6 @@
     <string name="settings_key_display_barcode_max_brightness" translatable="false">pref_display_card_max_brightness</string>
     <string name="settings_lock_barcode_orientation">Lock barcode orientation</string>
     <string name="settings_key_lock_barcode_orientation" translatable="false">pref_lock_barcode_orientation</string>
+    <string name="settings_keep_screen_on">Keep screen on</string>
+    <string name="settings_key_keep_screen_on" translatable="false">pref_keep_screen_on</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -50,6 +50,11 @@
             android:defaultValue="false"
             android:key="@string/settings_key_lock_barcode_orientation"
             android:title="@string/settings_lock_barcode_orientation"/>
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/settings_key_keep_screen_on"
+            android:title="@string/settings_keep_screen_on"/>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Implements a setting that keeps the screen on and the app above the keyguard when displaying a barcode (as discussed in #287).

*(I noticed my previous PR was on an old version so this is the same but rebased to master)*

Signed-off-by: `Miha Frangež<miha.frangez@gmail.com>`