### PR TITLE
Added ability to import a barcode from a local image

### DIFF
--- a/app/src/main/res/layout/loyalty_card_edit_activity.xml
+++ b/app/src/main/res/layout/loyalty_card_edit_activity.xml
@@ -368,12 +368,21 @@
                                   android:padding="10.0dip"
                                   android:layout_width="fill_parent"
                                   android:layout_height="wrap_content"
-                                  android:id="@+id/barcodeCaptureLayout">
+                                  android:id="@+id/barcodeCaptureLayout"
+                                  android:baselineAligned="false">
+
                         <Button android:id="@+id/captureButton"
                                 android:layout_width="0dp"
                                 android:layout_height="wrap_content"
                                 android:text="@string/capture"
                                 android:layout_weight="1.0"/>
+
+                        <Button android:id="@+id/importImageButton"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:text="@string/importImage"
+                                android:layout_weight="1.0"/>
+
                         <Button android:id="@+id/enterButton"
                                 android:layout_width="0dp"
                                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,4 +123,5 @@
     <string name="settings_key_display_barcode_max_brightness" translatable="false">pref_display_card_max_brightness</string>
     <string name="settings_lock_barcode_orientation">Lock barcode orientation</string>
     <string name="settings_key_lock_barcode_orientation" translatable="false">pref_lock_barcode_orientation</string>
+    <string name="importImage">Import from image</string>
 </resources>


### PR DESCRIPTION
Adds an "Import from image" button next to "Capture card" that does exactly what was described in #248 - allows the user to pick an image from their device that contains the barcode they want to add.

Signed-off-by: `Miha Frangež<miha.frangez@gmail.com>`