### PR TITLE
Fix converting loyalty card to barcodeless

### DIFF
--- a/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
+++ b/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
@@ -145,7 +145,7 @@ public class BarcodeSelectorActivity extends AppCompatActivity
             public void onClick(View view) {
                 Log.d(TAG, "Selected no barcode");
                 Intent result = new Intent();
-                result.putExtra(BARCODE_FORMAT, "");
+                result.putExtra(BARCODE_FORMAT, LoyaltyCardEditActivity.NO_BARCODE);
                 result.putExtra(BARCODE_CONTENTS, cardId);
                 BarcodeSelectorActivity.this.setResult(RESULT_OK, result);
                 finish();

--- a/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
+++ b/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
@@ -145,7 +145,7 @@ public class BarcodeSelectorActivity extends AppCompatActivity
             public void onClick(View view) {
                 Log.d(TAG, "Selected no barcode");
                 Intent result = new Intent();
-                result.putExtra(BARCODE_FORMAT, LoyaltyCardEditActivity.NO_BARCODE);
+                result.putExtra(BARCODE_FORMAT, "");
                 result.putExtra(BARCODE_CONTENTS, cardId);
                 BarcodeSelectorActivity.this.setResult(RESULT_OK, result);
                 finish();

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -37,7 +37,7 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
     private static final String TAG = "CardLocker";
     protected static final String NO_BARCODE = "_NO_BARCODE_";
 
-    private static final int SELECT_BARCODE_REQUEST = 1;
+    protected static final int SELECT_BARCODE_REQUEST = 1;
 
     EditText storeFieldEdit;
     EditText noteFieldEdit;
@@ -499,7 +499,7 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
         }
 
         if(contents != null && contents.isEmpty() == false &&
-                format != null && format.isEmpty() == false)
+                format != null)
         {
             Log.i(TAG, "Read barcode id: " + contents);
             Log.i(TAG, "Read format: " + format);
@@ -508,7 +508,8 @@ public class LoyaltyCardEditActivity extends AppCompatActivity
             cardIdView.setText(contents);
 
             final TextView barcodeTypeField = findViewById(R.id.barcodeType);
-            barcodeTypeField.setText(format);
+            // Set special NO_BARCODE value to prevent onResume from overwriting it
+            barcodeTypeField.setText(format.isEmpty() ? LoyaltyCardEditActivity.NO_BARCODE : format);
             onResume();
         }
     }

--- a/app/src/test/java/protect/card_locker/BarcodeSelectorActivityTest.java
+++ b/app/src/test/java/protect/card_locker/BarcodeSelectorActivityTest.java
@@ -64,9 +64,8 @@ public class BarcodeSelectorActivityTest {
         activity.findViewById(R.id.noBarcode).performClick();
         Intent resultIntent = shadowOf(activity).getResultIntent();
 
-        // The BarcodeSelectorActivity should return the special NO_BARCODE string to differentiate
-        // from nothing being set yet
-        assertEquals(LoyaltyCardEditActivity.NO_BARCODE, resultIntent.getStringExtra(BarcodeSelectorActivity.BARCODE_FORMAT));
+        // The BarcodeSelectorActivity should return an empty string
+        assertEquals("", resultIntent.getStringExtra(BarcodeSelectorActivity.BARCODE_FORMAT));
         assertEquals("abcdefg", resultIntent.getStringExtra(BarcodeSelectorActivity.BARCODE_CONTENTS));
     }
 

--- a/app/src/test/java/protect/card_locker/BarcodeSelectorActivityTest.java
+++ b/app/src/test/java/protect/card_locker/BarcodeSelectorActivityTest.java
@@ -63,7 +63,10 @@ public class BarcodeSelectorActivityTest {
         // Clicking button should create "empty" barcode
         activity.findViewById(R.id.noBarcode).performClick();
         Intent resultIntent = shadowOf(activity).getResultIntent();
-        assertEquals("", resultIntent.getStringExtra(BarcodeSelectorActivity.BARCODE_FORMAT));
+
+        // The BarcodeSelectorActivity should return the special NO_BARCODE string to differentiate
+        // from nothing being set yet
+        assertEquals(LoyaltyCardEditActivity.NO_BARCODE, resultIntent.getStringExtra(BarcodeSelectorActivity.BARCODE_FORMAT));
         assertEquals("abcdefg", resultIntent.getStringExtra(BarcodeSelectorActivity.BARCODE_CONTENTS));
     }
 

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -126,7 +126,16 @@ public class LoyaltyCardViewActivityTest
         assertEquals(store, card.store);
         assertEquals(note, card.note);
         assertEquals(cardId, card.cardId);
-        assertEquals(barcodeType, card.barcodeType);
+
+        // The special "No barcode" string shouldn't actually be written to the loyalty card
+        if(barcodeType.equals(LoyaltyCardEditActivity.NO_BARCODE))
+        {
+            assertEquals("", card.barcodeType);
+        }
+        else
+        {
+            assertEquals(barcodeType, card.barcodeType);
+        }
         assertNotNull(card.headerColor);
         assertNotNull(card.headerTextColor);
     }
@@ -539,7 +548,7 @@ public class LoyaltyCardViewActivityTest
         activityController.resume();
 
         // Save and check the loyalty card
-        saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, "", false);
+        saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, LoyaltyCardEditActivity.NO_BARCODE, false);
     }
 
     @Test

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -164,12 +164,44 @@ public class LoyaltyCardViewActivityTest
         assertNotNull(bundle);
 
         Intent resultIntent = new Intent(intent);
-        Bundle resultBuddle = new Bundle();
-        resultBuddle.putString(Intents.Scan.RESULT, BARCODE_DATA);
-        resultBuddle.putString(Intents.Scan.RESULT_FORMAT, BARCODE_TYPE);
-        resultIntent.putExtras(resultBuddle);
+        Bundle resultBundle = new Bundle();
+        resultBundle.putString(Intents.Scan.RESULT, BARCODE_DATA);
+        resultBundle.putString(Intents.Scan.RESULT_FORMAT, BARCODE_TYPE);
+        resultIntent.putExtras(resultBundle);
 
         // Respond to image capture, success
+        shadowOf(activity).receiveResult(
+                intent,
+                success ? Activity.RESULT_OK : Activity.RESULT_CANCELED,
+                resultIntent);
+    }
+
+    /**
+     * Initiate and complete a barcode selection, either in success
+     * or in failure
+     */
+    private void selectBarcodeWithResult(final Activity activity, final int buttonId, final String barcodeData, final String barcodeType, final boolean success) throws IOException
+    {
+        // Start image capture
+        final Button captureButton = activity.findViewById(buttonId);
+        captureButton.performClick();
+
+        ShadowActivity.IntentForResult intentForResult = shadowOf(activity).peekNextStartedActivityForResult();
+        assertNotNull(intentForResult);
+
+        Intent intent = intentForResult.intent;
+        assertNotNull(intent);
+
+        Bundle bundle = intent.getExtras();
+        assertNotNull(bundle);
+
+        Intent resultIntent = new Intent(intent);
+        Bundle resultBundle = new Bundle();
+        resultBundle.putString(BarcodeSelectorActivity.BARCODE_FORMAT, barcodeType);
+        resultBundle.putString(BarcodeSelectorActivity.BARCODE_CONTENTS, barcodeData);
+        resultIntent.putExtras(resultBundle);
+
+        // Respond to barcode selection, success
         shadowOf(activity).receiveResult(
                 intent,
                 success ? Activity.RESULT_OK : Activity.RESULT_CANCELED,
@@ -548,6 +580,32 @@ public class LoyaltyCardViewActivityTest
         activityController.resume();
 
         // Save and check the loyalty card
+        saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, LoyaltyCardEditActivity.NO_BARCODE, false);
+    }
+
+    @Test
+    public void removeBarcodeFromLoyaltyCard() throws IOException
+    {
+        ActivityController activityController = createActivityWithLoyaltyCard(true);
+        Activity activity = (Activity)activityController.get();
+        DBHelper db = new DBHelper(activity);
+
+        db.insertLoyaltyCard("store", "note", BARCODE_DATA, BARCODE_TYPE, Color.BLACK, Color.WHITE);
+
+        activityController.start();
+        activityController.visible();
+        activityController.resume();
+
+        // First check if the card is as expected
+        checkAllFields(activity, ViewMode.UPDATE_CARD, "store", "note", BARCODE_DATA, BARCODE_TYPE);
+
+        // Complete empty barcode selection successfully
+        selectBarcodeWithResult(activity, R.id.enterButton, BARCODE_DATA, "", true);
+
+        // Check if the barcode type is NO_BARCODE as expected
+        checkAllFields(activity, ViewMode.UPDATE_CARD, "store", "note", BARCODE_DATA, LoyaltyCardEditActivity.NO_BARCODE);
+
+        // Check if the special NO_BARCODE string doesn't get saved
         saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, LoyaltyCardEditActivity.NO_BARCODE, false);
     }
 


### PR DESCRIPTION
The LoyaltyCardEditActivity assumes on many places that an empty string
means it doesn't know a value yet. This patch ensures that the
BarcodeSelectorActivity returns a special string so that the
LoyaltyCardEditActivity can distinguish explicitly picking no barcode
from a not yet populated field.

Fixes #335. It does feel a bit hacky though...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brarcher/loyalty-card-locker/336)
<!-- Reviewable:end -->
