### PR TITLE
Reduce header size in landscape mode

### DIFF
--- a/app/src/main/res/layout-land/loyalty_card_view_layout.xml
+++ b/app/src/main/res/layout-land/loyalty_card_view_layout.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:fitsSystemWindows="true"
+    >
+
+    <FrameLayout
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="fill_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/centerGuideline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:layout_constraintGuide_percent="0.5"/>
+
+            <ImageView
+                android:id="@+id/barcode"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="20.0dip"
+                android:layout_marginBottom="10.0dip"
+                android:layout_marginStart="15.0dip"
+                android:layout_marginEnd="15.0dip"
+                app:layout_constraintBottom_toTopOf="@+id/centerGuideline"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                android:contentDescription="@string/barcodeImageDescription"/>
+
+            <TextView
+                android:id="@+id/cardIdView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginLeft="10.0dip"
+                android:layout_marginRight="10.0dip"
+                app:layout_constraintTop_toBottomOf="@+id/barcode"
+                app:layout_constraintBottom_toTopOf="@+id/noteViewDivider"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                android:textAlignment="center"
+                app:autoSizeTextType="uniform"
+                app:autoSizeMinTextSize="@dimen/singleCardCardIdTextSizeMin"
+                app:autoSizeMaxTextSize="@dimen/singleCardCardIdTextSizeMax"
+                android:ellipsize="end"
+                android:textIsSelectable="true"/>
+
+            <View
+                android:id="@id/noteViewDivider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@android:color/black"
+                app:layout_constraintTop_toBottomOf="@id/cardIdView"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="@+id/noteView"
+                />
+
+            <TextView
+                android:id="@id/noteView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_margin="10.0dip"
+                android:layout_gravity="bottom"
+                app:layout_constraintTop_toBottomOf="@id/noteViewDivider"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:autoSizeTextType="uniform"
+                app:autoSizeMinTextSize="@dimen/singleCardNoteTextSizeMin"
+                app:autoSizeMaxTextSize="@dimen/singleCardNoteTextSizeMax"
+                android:textIsSelectable="true"
+                android:scrollbars="vertical"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <View
+            android:id="@+id/drop_shadow_actionbar"
+            android:layout_width="fill_parent"
+            android:layout_height="5.0dip"
+            android:layout_gravity="top"/>
+    </FrameLayout>
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
+        android:background="@android:color/transparent"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:weightSum="1.0"
+        android:fitsSystemWindows="true">
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            android:id="@+id/collapsingToolbarLayout"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="56.0dip"
+            android:layout_weight="1.0"
+            app:expandedTitleMarginStart="48dp"
+            app:expandedTitleMarginEnd="64dp"
+            app:contentScrim="?colorPrimary"
+            app:expandedTitleGravity="top">
+            <TextView
+                android:id="@+id/storeName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:textColor="@android:color/white"
+                android:textSize="40sp"
+                android:textAlignment="center"
+                android:layout_gravity="top"
+                android:layout_marginTop="?actionBarSize"
+                android:layout_marginBottom="0dp"
+                app:layout_collapseMode="parallax"
+                android:fitsSystemWindows="true"/>
+            <androidx.appcompat.widget.Toolbar
+                android:id="@id/toolbar"
+                android:background="@android:color/transparent"
+                android:theme="@style/CardView.ActionBarTheme"
+                android:layout_width="fill_parent"
+                android:layout_height="?actionBarSize"
+                app:contentInsetStart="72.0dip"
+                app:layout_collapseMode="pin" />
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -35,7 +35,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowPackageManager;
 import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowLog;
 
@@ -257,6 +256,11 @@ public class LoyaltyCardViewActivityTest
 
         checkAllFields(activity, ViewMode.ADD_CARD, "", "", "", "");
     }
+    @Test @Config(qualifiers = "land")
+    public void startWithoutParametersCheckFieldsAvailableLandscape()
+    {
+        startWithoutParametersCheckFieldsAvailable();
+    }
 
     @Test
     public void startWithoutParametersCannotCreateLoyaltyCard()
@@ -273,7 +277,6 @@ public class LoyaltyCardViewActivityTest
 
         final EditText storeField = activity.findViewById(R.id.storeNameEdit);
         final EditText noteField = activity.findViewById(R.id.noteEdit);
-        final TextView cardIdField = activity.findViewById(R.id.cardIdView);
 
         shadowOf(activity).clickMenuItem(R.id.action_save);
         assertEquals(0, db.getLoyaltyCardCount());
@@ -285,6 +288,11 @@ public class LoyaltyCardViewActivityTest
         noteField.setText("note");
         shadowOf(activity).clickMenuItem(R.id.action_save);
         assertEquals(0, db.getLoyaltyCardCount());
+    }
+    @Test @Config(qualifiers = "land")
+    public void startWithoutParametersCannotCreateLoyaltyCardLandscape()
+    {
+        startWithoutParametersCannotCreateLoyaltyCard();
     }
 
     @Test
@@ -300,6 +308,11 @@ public class LoyaltyCardViewActivityTest
         assertEquals(false, activity.isFinishing());
         shadowOf(activity).clickMenuItem(android.R.id.home);
         assertEquals(true, activity.isFinishing());
+    }
+    @Test @Config(qualifiers = "land")
+    public void startWithoutParametersBackLandscape()
+    {
+        startWithoutParametersBack();
     }
 
     @Test
@@ -324,6 +337,11 @@ public class LoyaltyCardViewActivityTest
         // Save and check the loyalty card
         saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, BARCODE_TYPE, true);
     }
+    @Test @Config(qualifiers = "land")
+    public void startWithoutParametersCaptureBarcodeCreateLoyaltyCardLandscape() throws IOException
+    {
+        startWithoutParametersCaptureBarcodeCreateLoyaltyCard();
+    }
 
     @Test
     public void startWithoutParametersCaptureBarcodeFailure() throws IOException
@@ -341,6 +359,11 @@ public class LoyaltyCardViewActivityTest
         captureBarcodeWithResult(activity, R.id.captureButton, false);
 
         checkAllFields(activity, ViewMode.ADD_CARD, "", "", "", "");
+    }
+    @Test @Config(qualifiers = "land")
+    public void startWithoutParametersCaptureBarcodeFailureLandscape() throws IOException
+    {
+        startWithoutParametersCaptureBarcodeFailure();
     }
 
     @Test
@@ -364,6 +387,11 @@ public class LoyaltyCardViewActivityTest
         assertEquals(false, activity.isFinishing());
         shadowOf(activity).clickMenuItem(android.R.id.home);
         assertEquals(true, activity.isFinishing());
+    }
+    @Test @Config(qualifiers = "land")
+    public void startWithoutParametersCaptureBarcodeCancelLandscape() throws IOException
+    {
+        startWithoutParametersCaptureBarcodeCancel();
     }
 
     private ActivityController createActivityWithLoyaltyCard(boolean editMode)
@@ -405,6 +433,11 @@ public class LoyaltyCardViewActivityTest
 
         checkAllFields(activity, ViewMode.UPDATE_CARD, "store", "note", BARCODE_DATA, BARCODE_TYPE);
     }
+    @Test @Config(qualifiers = "land")
+    public void startWithLoyaltyCardEditModeCheckDisplayLandscape() throws IOException
+    {
+        startWithLoyaltyCardEditModeCheckDisplay();
+    }
 
     @Test
     public void startWithLoyaltyCardViewModeCheckDisplay() throws IOException
@@ -420,6 +453,11 @@ public class LoyaltyCardViewActivityTest
         activityController.resume();
 
         checkAllFields(activity, ViewMode.VIEW_CARD, "store", "note", BARCODE_DATA, BARCODE_TYPE);
+    }
+    @Test @Config(qualifiers = "land")
+    public void startWithLoyaltyCardViewModeCheckDisplayLandscape() throws IOException
+    {
+        startWithLoyaltyCardViewModeCheckDisplay();
     }
 
     @Test
@@ -441,6 +479,11 @@ public class LoyaltyCardViewActivityTest
         captureBarcodeWithResult(activity, R.id.captureButton, true);
 
         checkAllFields(activity, ViewMode.UPDATE_CARD, "store", "note", BARCODE_DATA, BARCODE_TYPE);
+    }
+    @Test @Config(qualifiers = "land")
+    public void startWithLoyaltyCardWithBarcodeUpdateBarcodeLandscape() throws IOException
+    {
+        startWithLoyaltyCardWithBarcodeUpdateBarcode();
     }
 
     @Test
@@ -468,6 +511,11 @@ public class LoyaltyCardViewActivityTest
         shadowOf(activity).clickMenuItem(android.R.id.home);
         assertEquals(true, activity.isFinishing());
     }
+    @Test @Config(qualifiers = "land")
+    public void startWithLoyaltyCardWithReceiptUpdateReceiptCancelLandscape() throws IOException
+    {
+        startWithLoyaltyCardWithReceiptUpdateReceiptCancel();
+    }
 
     @Test
     public void checkMenu() throws IOException
@@ -492,6 +540,11 @@ public class LoyaltyCardViewActivityTest
         assertEquals("Share", menu.findItem(R.id.action_share).getTitle().toString());
         assertEquals("Edit", menu.findItem(R.id.action_edit).getTitle().toString());
     }
+    @Test @Config(qualifiers = "land")
+    public void checkMenuLandscape() throws IOException
+    {
+        checkMenu();
+    }
 
     @Test
     public void startWithMissingLoyaltyCard() throws IOException
@@ -512,6 +565,11 @@ public class LoyaltyCardViewActivityTest
         activityController.stop();
         activityController.destroy();
     }
+    @Test @Config(qualifiers = "land")
+    public void startWithMissingLoyaltyCardLandscape() throws IOException
+    {
+        startWithMissingLoyaltyCard();
+    }
 
     @Test
     public void startWithoutParametersViewBack()
@@ -529,6 +587,11 @@ public class LoyaltyCardViewActivityTest
         assertEquals(false, activity.isFinishing());
         shadowOf(activity).clickMenuItem(android.R.id.home);
         assertEquals(true, activity.isFinishing());
+    }
+    @Test @Config(qualifiers = "land")
+    public void startWithoutParametersViewBackLandscape()
+    {
+        startWithoutParametersViewBack();
     }
 
     @Test
@@ -548,6 +611,11 @@ public class LoyaltyCardViewActivityTest
         shadowOf(activity).clickMenuItem(android.R.id.home);
         assertEquals(true, activity.isFinishing());
     }
+    @Test @Config(qualifiers = "land")
+    public void startWithoutColorsLandscape()
+    {
+        startWithoutColors();
+    }
 
     @Test
     public void startLoyaltyCardWithoutColorsSave() throws IOException
@@ -565,6 +633,11 @@ public class LoyaltyCardViewActivityTest
         // Save and check the loyalty card
         saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, BARCODE_TYPE, false);
     }
+    @Test @Config(qualifiers = "land")
+    public void startLoyaltyCardWithoutColorsSaveLandscape() throws IOException
+    {
+        startLoyaltyCardWithoutColorsSave();
+    }
 
     @Test
     public void startLoyaltyCardWithExplicitNoBarcodeSave() throws IOException
@@ -581,6 +654,11 @@ public class LoyaltyCardViewActivityTest
 
         // Save and check the loyalty card
         saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, LoyaltyCardEditActivity.NO_BARCODE, false);
+    }
+    @Test @Config(qualifiers = "land")
+    public void startLoyaltyCardWithExplicitNoBarcodeSaveLandscape() throws IOException
+    {
+        startLoyaltyCardWithExplicitNoBarcodeSave();
     }
 
     @Test
@@ -607,6 +685,11 @@ public class LoyaltyCardViewActivityTest
 
         // Check if the special NO_BARCODE string doesn't get saved
         saveLoyaltyCardWithArguments(activity, "store", "note", BARCODE_DATA, LoyaltyCardEditActivity.NO_BARCODE, false);
+    }
+    @Test @Config(qualifiers = "land")
+    public void removeBarcodeFromLoyaltyCardLandscape() throws IOException
+    {
+        removeBarcodeFromLoyaltyCard();
     }
 
     @Test
@@ -648,6 +731,11 @@ public class LoyaltyCardViewActivityTest
         shadowOf(activity).clickMenuItem(android.R.id.home);
         assertEquals(true, activity.isFinishing());
     }
+    @Test @Config(qualifiers = "land")
+    public void startCheckFontSizesLandscape()
+    {
+        startCheckFontSizes();
+    }
 
     @Test
     public void checkScreenOrientationLockSetting()
@@ -685,6 +773,11 @@ public class LoyaltyCardViewActivityTest
             }
         }
     }
+    @Test @Config(qualifiers = "land")
+    public void checkScreenOrientationLockSettingLandscape()
+    {
+        checkScreenOrientationLockSetting();
+    }
 
     @Test
     public void importCard()
@@ -705,5 +798,10 @@ public class LoyaltyCardViewActivityTest
         checkAllFields(activity, ViewMode.ADD_CARD, "Example Store", "", "123456", "AZTEC");
         assertEquals(-416706, ((ColorDrawable) activity.findViewById(R.id.headingColorSample).getBackground()).getColor());
         assertEquals(-1, ((ColorDrawable) activity.findViewById(R.id.headingStoreTextColorSample).getBackground()).getColor());
+    }
+    @Test @Config(qualifiers = "land")
+    public void importCardLandscape()
+    {
+        importCard();
     }
 }


### PR DESCRIPTION
Improves #268

Before:
![photo_2020-01-07_20-35-20](https://user-images.githubusercontent.com/1885159/71923399-3d7d6800-318d-11ea-8481-70aa76136fae.jpg)
After:
![photo_2020-01-07_20-35-19](https://user-images.githubusercontent.com/1885159/71923404-42421c00-318d-11ea-9f90-f311217b489a.jpg)

It's a small but good difference, a "start" so to say (Android layout code is very frustrating and I don't feel like spending more time on it).

The code changes may seem very big, but they are in fact pretty small:
- I created a copy of the current view theme in layout-land for landscape layouts, and slightly tweaked the TextView
- I added some extra lines to the tests to ensure we run all the tests in landscape view as well, so errors in the landscape layout won't go unnoticed

The other option was to write code in the LoyaltyCardViewActivity class to check the orientation and make some UI changes. While this would be less code and less (UI) code duplication, I felt patching around in the UI like that when Android provides a native mechanism would be less maintainable, which is why I opted for this way of implementing the change.

If you have any more suggestions on how the landscape UI can be tweaked please mention it, I'm honestly not quite sure what to do while keeping it as pretty as it currently is.