### PR TITLE
Move barcode to top on tap

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -145,6 +145,12 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
 
         Log.i(TAG, "To view card: " + loyaltyCardId);
 
+        if(barcodeIsFullscreen)
+        {
+            // Properly reset state to prevent any issues
+            recreate();
+        }
+
         // The brightness value is on a scale from [0, ..., 1], where
         // '1' is the brightest. We attempt to maximize the brightness
         // to help barcode readers scan the barcode.

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -119,11 +119,11 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
             public void onClick(View view) {
                 if(barcodeIsFullscreen)
                 {
-                    setBarcodeFullscreen(false);
+                    setFullscreen(false);
                 }
                 else
                 {
-                    setBarcodeFullscreen(true);
+                    setFullscreen(true);
                 }
             }
         });
@@ -147,7 +147,10 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
 
         if(barcodeIsFullscreen)
         {
-            // Properly reset state to prevent any issues
+            // Completely reset state
+            //
+            // This prevents the barcode from taking up the entire screen
+            // on resume and thus being stretched out of proportion.
             recreate();
         }
 
@@ -277,7 +280,7 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
     public void onBackPressed() {
         if (barcodeIsFullscreen)
         {
-            setBarcodeFullscreen(false);
+            setFullscreen(false);
             return;
         }
 
@@ -363,10 +366,16 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
         }
     }
 
-    private void setBarcodeFullscreen(boolean enabled)
+    /**
+     * When enabled, hides the status bar and moves the barcode to the top of the screen.
+     *
+     * The purpose of this function is to make sure the barcode can be scanned from the phone
+     * by machines which offer no space to insert the complete device.
+     */
+    private void setFullscreen(boolean enable)
     {
         ActionBar actionBar = getSupportActionBar();
-        if(enabled && !barcodeIsFullscreen)
+        if(enable && !barcodeIsFullscreen)
         {
             // Save previous barcodeImage state
             barcodeImageState = barcodeImage.getLayoutParams();
@@ -399,7 +408,7 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
             // Set current state
             barcodeIsFullscreen = true;
         }
-        else if(!enabled && barcodeIsFullscreen)
+        else if(!enable && barcodeIsFullscreen)
         {
             // Show actionbar
             if(actionBar != null)

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -738,21 +738,6 @@ public class LoyaltyCardViewActivityTest
         assertEquals(uiOptions | View.SYSTEM_UI_FLAG_FULLSCREEN, uiOptions);
         assertEquals(View.GONE, collapsingToolbarLayout.getVisibility());
 
-        // Resuming the activity should revert the state to normal view
-        activityController.pause();
-        activityController.resume();
-        uiOptions = activity.getWindow().getDecorView().getSystemUiVisibility();
-        assertNotEquals(uiOptions | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY, uiOptions);
-        assertNotEquals(uiOptions | View.SYSTEM_UI_FLAG_FULLSCREEN, uiOptions);
-        assertEquals(View.VISIBLE, collapsingToolbarLayout.getVisibility());
-
-        // Clicking the barcode should still work to fullscreen again
-        barcodeImage.performClick();
-        uiOptions = activity.getWindow().getDecorView().getSystemUiVisibility();
-        assertEquals(uiOptions | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY, uiOptions);
-        assertEquals(uiOptions | View.SYSTEM_UI_FLAG_FULLSCREEN, uiOptions);
-        assertEquals(View.GONE, collapsingToolbarLayout.getVisibility());
-
         // In full screen mode, back button should disable fullscreen
         activity.onBackPressed();
         uiOptions = activity.getWindow().getDecorView().getSystemUiVisibility();

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -738,6 +738,21 @@ public class LoyaltyCardViewActivityTest
         assertEquals(uiOptions | View.SYSTEM_UI_FLAG_FULLSCREEN, uiOptions);
         assertEquals(View.GONE, collapsingToolbarLayout.getVisibility());
 
+        // Resuming the activity should revert the state to normal view
+        activityController.pause();
+        activityController.resume();
+        uiOptions = activity.getWindow().getDecorView().getSystemUiVisibility();
+        assertNotEquals(uiOptions | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY, uiOptions);
+        assertNotEquals(uiOptions | View.SYSTEM_UI_FLAG_FULLSCREEN, uiOptions);
+        assertEquals(View.VISIBLE, collapsingToolbarLayout.getVisibility());
+
+        // Clicking the barcode should still work to fullscreen again
+        barcodeImage.performClick();
+        uiOptions = activity.getWindow().getDecorView().getSystemUiVisibility();
+        assertEquals(uiOptions | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY, uiOptions);
+        assertEquals(uiOptions | View.SYSTEM_UI_FLAG_FULLSCREEN, uiOptions);
+        assertEquals(View.GONE, collapsingToolbarLayout.getVisibility());
+
         // In full screen mode, back button should disable fullscreen
         activity.onBackPressed();
         uiOptions = activity.getWindow().getDecorView().getSystemUiVisibility();


### PR DESCRIPTION
On a tap of the barcode, moves the barcode to the top of the screen. On another tap, move things back to normal. On the second screenshot, the top bar is normally hidden, it is only visible because creating a screenshot makes it reappear. Fixes #143.

![photo_2020-01-19_19-09-08](https://user-images.githubusercontent.com/1885159/72685935-33ddf380-3aef-11ea-9c48-92992fa83aa8.jpg)
![photo_2020-01-19_19-09-10](https://user-images.githubusercontent.com/1885159/72685934-33ddf380-3aef-11ea-880d-acda337337b9.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brarcher/loyalty-card-locker/348)
<!-- Reviewable:end -->
