### PR TITLE
Fix barcode centering when leaving fullscreen

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -405,6 +405,9 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
             // Move barcode to top
             barcodeImage.setScaleType(ImageView.ScaleType.FIT_START);
 
+            // Prevent centering
+            barcodeImage.setAdjustViewBounds(false);
+
             // Set current state
             barcodeIsFullscreen = true;
         }
@@ -428,6 +431,9 @@ public class LoyaltyCardViewActivity extends AppCompatActivity
 
             // Turn barcode back to normal
             barcodeImage.setLayoutParams(barcodeImageState);
+
+            // Fix barcode centering
+            barcodeImage.setAdjustViewBounds(true);
 
             // Set current state
             barcodeIsFullscreen = false;


### PR DESCRIPTION
#329 seems to have broken #348 somewhat, making the barcode non-centered when leaving fullscreen.

This pull request fixes this.

Screenshots of behaviour before applying this patch (normal -> fullscreen -> normal)
![Screenshot_1580229214](https://user-images.githubusercontent.com/1885159/73284245-93758680-41f4-11ea-95e3-120df0c2724c.png)
![Screenshot_1580229217](https://user-images.githubusercontent.com/1885159/73284278-9ec8b200-41f4-11ea-8522-c93f7ce41e17.png)
![Screenshot_1580229219](https://user-images.githubusercontent.com/1885159/73284279-9f614880-41f4-11ea-9798-8937f5372f3b.png)