### PR TITLE
Choose export location

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportExportTask.java
+++ b/app/src/main/java/protect/card_locker/ImportExportTask.java
@@ -4,16 +4,12 @@ import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.os.AsyncTask;
-import android.os.Environment;
 import android.util.Log;
-import android.widget.Toast;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 
@@ -24,7 +20,7 @@ class ImportExportTask extends AsyncTask<Void, Void, Boolean>
     private Activity activity;
     private boolean doImport;
     private DataFormat format;
-    private File target;
+    private OutputStream outputStream;
     private InputStream inputStream;
     private TaskCompleteListener listener;
 
@@ -33,14 +29,14 @@ class ImportExportTask extends AsyncTask<Void, Void, Boolean>
     /**
      * Constructor which will setup a task for exporting to the given file
      */
-    ImportExportTask(Activity activity, DataFormat format, File target,
+    ImportExportTask(Activity activity, DataFormat format, OutputStream output,
             TaskCompleteListener listener)
     {
         super();
         this.activity = activity;
         this.doImport = false;
         this.format = format;
-        this.target = target;
+        this.outputStream = output;
         this.listener = listener;
     }
 
@@ -78,14 +74,13 @@ class ImportExportTask extends AsyncTask<Void, Void, Boolean>
         return result;
     }
 
-    private boolean performExport(File exportFile, DBHelper db)
+    private boolean performExport(OutputStream stream, DBHelper db)
     {
         boolean result = false;
 
         try
         {
-            FileOutputStream fileWriter = new FileOutputStream(exportFile);
-            OutputStreamWriter writer = new OutputStreamWriter(fileWriter, Charset.forName("UTF-8"));
+            OutputStreamWriter writer = new OutputStreamWriter(stream, Charset.forName("UTF-8"));
             result = MultiFormatExporter.exportData(db, writer, format);
             writer.close();
         }
@@ -94,7 +89,7 @@ class ImportExportTask extends AsyncTask<Void, Void, Boolean>
             Log.e(TAG, "Unable to export file", e);
         }
 
-        Log.i(TAG, "Export of '" + exportFile.getAbsolutePath() + "' result: " + result);
+        Log.i(TAG, "Export result: " + result);
 
         return result;
     }
@@ -127,7 +122,7 @@ class ImportExportTask extends AsyncTask<Void, Void, Boolean>
         }
         else
         {
-            result = performExport(target, db);
+            result = performExport(outputStream, db);
         }
 
         return result;

--- a/app/src/main/res/layout/import_export_activity.xml
+++ b/app/src/main/res/layout/import_export_activity.xml
@@ -99,7 +99,6 @@
                 android:layout_marginTop="8dp"
                 android:text="@string/importOptionFilesystemButton" />
 
-
             <View
                 android:id="@+id/dividerImportApplication"
                 android:layout_width="fill_parent"
@@ -129,36 +128,6 @@
                 android:layout_gravity="center_horizontal"
                 android:layout_marginTop="8dp"
                 android:text="@string/importOptionApplicationButton" />
-
-            <View
-                android:id="@+id/dividerImportFixed"
-                android:layout_width="fill_parent"
-                android:layout_height="1dp"
-                android:layout_margin="16dp"
-                android:background="?android:attr/listDivider"/>
-
-            <TextView
-                android:id="@+id/importOptionFixedTitle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textSize="@dimen/text_size_large"
-                android:text="@string/importOptionFixedTitle"/>
-
-            <TextView
-                android:id="@+id/importOptionFixedExplanation"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:textSize="@dimen/text_size_medium"
-                android:text="@string/importOptionFixedExplanation"/>
-
-            <Button
-                android:id="@+id/importOptionFixedButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="8dp"
-                android:text="@string/importOptionFixedButton" />
         </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -8,7 +8,6 @@
     <string name="storeName">Obchod</string>
     <string name="note">Poznámka</string>
     <string name="cardId">ID karty</string>
-    <string name="barcodeType">Typ čárového kódu</string>
     <string name="cancel">Zrušit</string>
     <string name="save">Uložit</string>
     <string name="capture">Naskenovat kartu</string>
@@ -23,20 +22,16 @@
     <string name="sendLabel">Odeslat&#8230;</string>
     <string name="editCardTitle">Editovat věrnostní kartu</string>
     <string name="addCardTitle">Přidat věrnostní kartu</string>
-    <string name="viewCardTitle">Zobrazit věrnostní kartu</string>
     <string name="scanCardBarcode">Oskenujte kód karty</string>
     <string name="barcodeImageDescription">Obrázek kódu karty</string>
 
     <string name="noStoreError">Nebyl zadán Obchod</string>
     <string name="noCardIdError">Nebylo zadáno ID karty</string>
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Import/Export</string>
-    <string name="importName">Import</string>
     <string name="exportName">Export</string>
     <string name="importExportHelp">Zálohování dat vám umožní přesunout vaše uložené karty na jiné zařízení.</string>
     <string name="importedFrom">Importováno z: %1$s</string>
     <string name="exportedTo">Exportováno do: %1$s</string>
-    <string name="fileMissing">Doubor chybí: %1$s</string>
     <string name="importSuccessfulTitle">Import proběhl úspěšně</string>
     <string name="importFailedTitle">Import selhal</string>
     <string name="importFailed">Import selhal: %1$s</string>
@@ -53,9 +48,6 @@
     <string name="importOptionApplicationTitle">Použít externí aplikaci</string>
     <string name="importOptionApplicationExplanation">K otevření souboru použije externí aplikaci jako Dropbox, Google Drive, nebo vámi preferovaný prohlížeč souborů.</string>
     <string name="importOptionApplicationButton">Použít externí aplikaci</string>
-    <string name="importOptionFixedTitle">Import z umístění exportu</string>
-    <string name="importOptionFixedExplanation">Import ze stejné složky souborového systému do níž se zapisuje při exportu.</string>
-    <string name="importOptionFixedButton">Použít složku exportu</string>
 
     <string name="about">O aplikaci</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -11,7 +11,6 @@
     <string name="storeName">Geschäft</string>
     <string name="note">Notiz</string>
     <string name="cardId">Kartennummer</string>
-    <string name="barcodeType">Barcodeart</string>
     <string name="cancel">Abbrechen</string>
     <string name="save">Speichern</string>
     <string name="capture">Karte scannen</string>
@@ -27,11 +26,9 @@
     <string name="ok">Ok</string>
     <string name="copy_to_clipboard">Kopiere die Nummer in die Zwischenablage</string>
     <string name="sendLabel">Senden&#8230;</string>
-    <string name="addedShortcut">Zum Home Screen hinzugefügt</string>
 
     <string name="editCardTitle">Kundenkarte bearbeiten</string>
     <string name="addCardTitle">Neue Kundenkarte</string>
-    <string name="viewCardTitle">Kundenkarte anzeigen</string>
     <string name="scanCardBarcode">Barcode scannen</string>
     <string name="cardShortcut">Shortcut zu einer Karte</string>
     <string name="noCardsMessage">Es ist noch keine Karte vorhanden, bitte zuerst eine hinzufügen</string>
@@ -41,14 +38,11 @@
     <string name="noStoreError">Kein Geschäft angegeben</string>
     <string name="noCardIdError">Keine Kartennummer angegeben</string>
     <string name="noCardExistsError">Karte konnte nicht gefunden werden</string>
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Import/Export</string>
-    <string name="importName">Import</string>
     <string name="exportName">Exportieren</string>
     <string name="importExportHelp">Gesicherte Daten ermöglichen das Verschieben der Kundenkarten auf ein anderes Gerät.</string>
     <string name="importedFrom">Importiert von: %1$s</string>
     <string name="exportedTo">Exportiert nach: %1$s</string>
-    <string name="fileMissing">Datei fehlt: %1$s</string>
     <string name="importSuccessfulTitle">Import erfolgreich</string>
     <string name="importFailedTitle">Import fehlgeschlagen</string>
     <string name="importFailed">Import fehlgeschlagen: %1$s</string>
@@ -65,9 +59,6 @@
     <string name="importOptionApplicationTitle">Externe App verwenden</string>
     <string name="importOptionApplicationExplanation">Wählen Sie eine Datei aus einer App wie Dropbox, Google Drive, oder Ihrem bevorzugten Dateisystem aus.</string>
     <string name="importOptionApplicationButton">Nutze eine externe App</string>
-    <string name="importOptionFixedTitle">Importiere aus Export-Pfad</string>
-    <string name="importOptionFixedExplanation">Nutze den Export-Pfad, um Karten zu importieren (dies stellt zuvor gesicherte Daten wieder her).</string>
-    <string name="importOptionFixedButton">Export-Pfad verwenden</string>
 
     <string name="about">Über</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -8,7 +8,6 @@
     <string name="storeName">Κατάστημα</string>
     <string name="note">Σημείωση</string>
     <string name="cardId">Κωδικός Κάρτας</string>
-    <string name="barcodeType">Τύπος Barcode</string>
     <string name="cancel">Άκυρο</string>
     <string name="save">Αποθήκευση</string>
     <string name="capture">Φωτογράφιση Κάρτας</string>
@@ -24,11 +23,9 @@
     <string name="ok">OK</string>
     <string name="copy_to_clipboard">Αντιγραφή κωδικού στο πρόχειρο</string>
     <string name="sendLabel">Αποστολή&#8230;</string>
-    <string name="addedShortcut">Προστέθηκε στην Αρχική Οθόνη</string>
 
     <string name="editCardTitle">Επεξεργασία Κάρτας</string>
     <string name="addCardTitle">Προσθήκη Κάρτας</string>
-    <string name="viewCardTitle">Εμφάνιση Κάρτας</string>
     <string name="scanCardBarcode">Σαρώστε τον κωδικό της κάρτας</string>
     <string name="cardShortcut">Συντόμευση Κάρτας</string>
     <string name="noCardsMessage">Δεν υπάρχουν κάρτες. προσθέστε μία πρώτα</string>
@@ -38,14 +35,11 @@
     <string name="noStoreError">Δεν δώσατε κατάστημα</string>
     <string name="noCardIdError">Δεν δώσατε κωδικό κάρτας</string>
     <string name="noCardExistsError">Δεν ήταν δυνατό να εντοπιστεί κάρτα</string>
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Εισαγωγή/Εξαγωγή</string>
-    <string name="importName">Εισαγωγή</string>
     <string name="exportName">Εξαγωγή</string>
     <string name="importExportHelp">Τα εφεδρικά δεδομένα σας δίνουν την δυνατότητα να μεταφέρετε τις κάρτες σας σε μία άλλη συσκευή.</string>
     <string name="importedFrom">Εισαγωγή από: %1$s</string>
     <string name="exportedTo">Εξαγωγή σε: %1$s</string>
-    <string name="fileMissing">Το αρχείο λείπει: %1$s</string>
     <string name="importSuccessfulTitle">Εισαγωγή επιτυχής</string>
     <string name="importFailedTitle">Εισαγωγή ανεπιτυχής</string>
     <string name="importFailed">Δεν εισήχθει: %1$s</string>
@@ -62,9 +56,6 @@
     <string name="importOptionApplicationTitle">Χρήση εξωτερικής εφαρμογής</string>
     <string name="importOptionApplicationExplanation">Κάντε χρήση μίας εξωτερικής εφαρμογής όπως είναι τα Dropbox, Google Drive ή ο αγαπημένος σας διαχειριστής αρχείων για να ανοίξετε ένα αρχείο.</string>
     <string name="importOptionApplicationButton">Χρήση εξωτερικής εφαρμογής</string>
-    <string name="importOptionFixedTitle">Εισαγωγή από τοποθεσία εξαγωγής</string>
-    <string name="importOptionFixedExplanation">Εισαγωγή από την ίδια τοποθεσία στο σύστημα αρχείων, στην οποία γίνεται αποθήκευση κατά την εξαγωγή.</string>
-    <string name="importOptionFixedButton">Χρήση τοποθεσίας εξαγωγής</string>
 
     <string name="about">Σχετικά</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -8,7 +8,6 @@
     <string name="storeName">Tienda</string>
     <string name="note">Nota</string>
     <string name="cardId">ID de la Tarjeta</string>
-    <string name="barcodeType">Tipo de Código de Barras</string>
     <string name="cancel">Cancelar</string>
     <string name="save">Guardar</string>
     <string name="capture">Escanear Tarjeta</string>
@@ -24,11 +23,9 @@
     <string name="ok">OK</string>
     <string name="copy_to_clipboard">Copiar ID al portapapeles</string>
     <string name="sendLabel">Enviar&#8230;</string>
-    <string name="addedShortcut">Añadido a la Pantalla de Inicio</string>
 
     <string name="editCardTitle">Editar Tarjeta de Fidelización</string>
     <string name="addCardTitle">Añadir Tarjeta de Fidelización</string>
-    <string name="viewCardTitle">Ver Tarjeta de Fidelización</string>
     <string name="scanCardBarcode">Escanear el Código de Barras de la Tarjeta</string>
     <string name="cardShortcut">Atajo de Tarjeta</string>
     <string name="noCardsMessage">No hay ninguna tarjeta, añade una primero</string>
@@ -38,14 +35,11 @@
     <string name="noStoreError">Establecimiento no especificado</string>
     <string name="noCardIdError">ID de la Tarjeta no especificado</string>
     <string name="noCardExistsError">No se ha podido encontrar la tarjeta de fidelización</string>
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Importar/Exportar</string>
-    <string name="importName">Importar</string>
     <string name="exportName">Exportar</string>
     <string name="importExportHelp">La copia de seguridad te permite transferir tus tarjetas a otro dispositivo.</string>
     <string name="importedFrom">Importar desde: %1$s</string>
     <string name="exportedTo">Exportar a: %1$s</string>
-    <string name="fileMissing">Archivo perdido: %1$s</string>
     <string name="importSuccessfulTitle">Datos importados correctamente</string>
     <string name="importFailedTitle">Ha ocurrido un error al importar los datos</string>
     <string name="importFailed">Error al importar: %1$s</string>
@@ -62,9 +56,6 @@
     <string name="importOptionApplicationTitle">Usar una applicación externa</string>
     <string name="importOptionApplicationExplanation">Use una aplicación externa como Dropbox, Google Drive o tu gestor de archivos favoritos para abrir un archivo.</string>
     <string name="importOptionApplicationButton">Usar aplicación externa</string>
-    <string name="importOptionFixedTitle">Importar desde el lugar donde los datos son exportados</string>
-    <string name="importOptionFixedExplanation">Importar desde el mismo lugar en el sistema de archivos donde los datos son exportados.</string>
-    <string name="importOptionFixedButton">Utilizar el lugar donde los datos son exportados</string>
 
     <string name="about">Acerca de</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -8,7 +8,6 @@
     <string name="storeName">Nom</string>
     <string name="note">Note</string>
     <string name="cardId">Numéro</string>
-    <string name="barcodeType">Type de code-barres</string>
     <string name="cancel">Annuler</string>
     <string name="save">Enregistrer</string>
     <string name="capture">Mode capture</string>
@@ -24,11 +23,9 @@
     <string name="ok">OK</string>
     <string name="copy_to_clipboard">Copier le numéro dans le presse-papier</string>
     <string name="sendLabel">Envoyer&#8230;</string>
-    <string name="addedShortcut">Ajouter à l\'écran d\'accueil</string>
 
     <string name="editCardTitle">Modifier la carte de fidélité</string>
     <string name="addCardTitle">Ajouter une carte de fidélité</string>
-    <string name="viewCardTitle">Voir la carte de fidélité</string>
     <string name="scanCardBarcode">Flasher le code-barres de la carte</string>
     <string name="cardShortcut">Raccourci de carte</string>
     <string name="noCardsMessage">Il n\'y a aucune carte. Ajoutez en une d\'abord.</string>
@@ -38,14 +35,11 @@
     <string name="noStoreError">Aucun nom n\'a été saisi</string>
     <string name="noCardIdError">Aucun numéro n\'a été saisi</string>
     <string name="noCardExistsError">N\'a pas pu retrouver la carte de fidélité</string>
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Importer/Exporter</string>
-    <string name="importName">Importer</string>
     <string name="exportName">Exporter</string>
     <string name="importExportHelp">Exporter vos données vous permet de récupérer vos cartes sur un autre appareil.</string>
     <string name="importedFrom">Importé depuis : %1$s</string>
     <string name="exportedTo">Exporté vers : %1$s</string>
-    <string name="fileMissing">Fichier manquant : %1$s</string>
     <string name="importSuccessfulTitle">Importé avec succès</string>
     <string name="importFailedTitle">Échec de l\'import</string>
     <string name="importFailed">Échec de l\'import : %1$s</string>
@@ -62,9 +56,6 @@
     <string name="importOptionApplicationTitle">Application externe</string>
     <string name="importOptionApplicationExplanation">Utilisez une application externe comme Dropbox, Google Drive, ou votre gestionnaire de fichiers favori pour ouvrir un fichier.</string>
     <string name="importOptionApplicationButton">Application externe</string>
-    <string name="importOptionFixedTitle">Importer depuis le même emplacement que pour l\'export</string>
-    <string name="importOptionFixedExplanation">Importe les données depuis le même emplacement que celui défini pour l\'export.</string>
-    <string name="importOptionFixedButton">Utiliser l\'emplacement de l\'export</string>
 
     <string name="about">À propos</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-he-rIL/strings.xml
+++ b/app/src/main/res/values-he-rIL/strings.xml
@@ -4,7 +4,6 @@
     <string name="action_add">הוספה</string>
 
     <string name="cardId">מזהה כרטיס</string>
-    <string name="barcodeType">סוג ברקוד</string>
     <string name="cancel">ביטול</string>
     <string name="save">שמור</string>
     <string name="capture">צלם כרטיס</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -11,7 +11,6 @@
     <string name="storeName">Negozio</string>
     <string name="note">Note</string>
     <string name="cardId">Codice</string>
-    <string name="barcodeType">Tipo codice a barre</string>
     <string name="barcodeNoBarcode">Questa carta non ha un codice a barre</string>
 
     <string name="cancel">Annulla</string>
@@ -30,11 +29,9 @@
     <string name="copy_to_clipboard">Copia ID negli appunti</string>
     <string name="share">Condividi</string>
     <string name="sendLabel">Invia&#8230;</string>
-    <string name="addedShortcut">Aggiunto al launcher</string>
 
     <string name="editCardTitle">Modifica carta</string>
     <string name="addCardTitle">Aggiungi carta</string>
-    <string name="viewCardTitle">Mostra carta</string>
     <string name="scanCardBarcode">Scansiona codice carta</string>
     <string name="cardShortcut">Scorciatoia per la carta</string>
     <string name="noCardsMessage">Non ci sono carte. Aggiungine prima una</string>
@@ -46,14 +43,11 @@
     <string name="noCardExistsError">Impossibile trovare la carta</string>
     <string name="failedParsingImportUriError">Impossibile analizzare l\'URI</string>
 
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Importa/Esporta</string>
-    <string name="importName">Importa</string>
     <string name="exportName">Esporta</string>
     <string name="importExportHelp">Fare il backup dei dati ti permette di spostare le tue carte da un dispositivo ad un altro.</string>
     <string name="importedFrom">Importato da: %1$s</string>
     <string name="exportedTo">Esportato in: %1$s</string>
-    <string name="fileMissing">File mancante: %1$s</string>
     <string name="importSuccessfulTitle">Importazione avvenuta con successo</string>
     <string name="importFailedTitle">Importazione fallita</string>
     <string name="importFailed">Impossibile importare: %1$s</string>
@@ -70,9 +64,6 @@
     <string name="importOptionApplicationTitle">Usa un\'applicazione esterna</string>
     <string name="importOptionApplicationExplanation">Usa un\'applicazione esterna come Dropbox, Google Drive o il tuo file manager preferito per aprire il file.</string>
     <string name="importOptionApplicationButton">Usa un\'applicazione esterna</string>
-    <string name="importOptionFixedTitle">Importa da un altro posto</string>
-    <string name="importOptionFixedExplanation">Importa dallo stesso posto del file system dove si è esportato.</string>
-    <string name="importOptionFixedButton">Usa luogo dell\'esportazione</string>
 
     <string name="about">Informazioni</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -8,7 +8,6 @@
     <string name="storeName">Parduotuvė</string>
     <string name="note">Užrašas</string>
     <string name="cardId">Kortelės ID</string>
-    <string name="barcodeType">Brūkšninio kodo tipas</string>
     <string name="cancel">Atšaukti</string>
     <string name="save">Išsaugoti</string>
     <string name="capture">Nufotografuoti kortelę</string>
@@ -22,19 +21,15 @@
     <string name="copy_to_clipboard">Nukopijuoti ID į iškarpinę</string>
     <string name="editCardTitle">Redaguoti lojalumo kortelę</string>
     <string name="addCardTitle">Pridėti lojalumo kortelę</string>
-    <string name="viewCardTitle">Paeržiūrėti lojalumo kortelę</string>
     <string name="scanCardBarcode">Nuskanuokite kortelės brūkšninį kodą</string>
     <string name="barcodeImageDescription">Kortelės brūkšninio kodo paveikslėlis</string>
 
     <string name="noStoreError">Parduotuvė neįvesta</string>
     <string name="noCardIdError">Neįvestas kortelės ID</string>
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Importuoti/Exportuoti</string>
-    <string name="importName">Importuoti</string>
     <string name="exportName">Exportuoti</string>
     <string name="importedFrom">Importuota iš: %1$s</string>
     <string name="exportedTo">Eksportuota į: %1$s</string>
-    <string name="fileMissing">Failas nerastas: %1$s</string>
     <string name="importFailed">Nepavyko importuoti: %1$s</string>
     <string name="exportFailed">Nepavyko eksportuoti: %1$s</string>
     <string name="importing">Importuoja&#8230;</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -54,9 +54,6 @@
     <string name="importOptionApplicationTitle">Brukt eksternt program</string>
     <string name="importOptionApplicationExplanation">Bruk eksternt program som Nextcloud, eller din favorittfilbehandler til å åpne ei fil.</string>
     <string name="importOptionApplicationButton">Bruk eksternt program</string>
-    <string name="importOptionFixedTitle">Importer fra eksporteringsområde</string>
-    <string name="importOptionFixedExplanation">Importer fra området i filsystemet eksporter skrives til.</string>
-    <string name="importOptionFixedButton">Bruk eksporteringsplassering</string>
     <string name="about">Om</string>
     <string name="app_copyright_fmt">Kopirett 2016-<xliff:g>%d</xliff:g> Branden Archer</string>
     <string name="app_license">Lisensiert GPLv3+.</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -9,7 +9,6 @@
     <string name="storeName">Butikk</string>
     <string name="note">Merknad</string>
     <string name="cardId">Kort-ID</string>
-    <string name="barcodeType">Strekkodetype</string>
 
     <string name="cancel">Avbryt</string>
     <string name="save">Lagre</string>
@@ -26,11 +25,9 @@
     <string name="ok">OK</string>
     <string name="copy_to_clipboard">Kopier ID til utklippstavle</string>
     <string name="sendLabel">Send&#8230;</string>
-    <string name="addedShortcut">Lagt til på hjemmeskjerm</string>
 
     <string name="editCardTitle">Rediger kundekort</string>
     <string name="addCardTitle">Legg til kundekort</string>
-    <string name="viewCardTitle">Vis kundekort</string>
     <string name="scanCardBarcode">Skann kortets strekkode</string>
     <string name="cardShortcut">Kort-snarvei</string>
     <string name="noCardsMessage">Legg til et kort først</string>
@@ -41,16 +38,11 @@
     <string name="noCardIdError">Ingen kort-ID innskrevet</string>
     <string name="noCardExistsError">Kunne ikke finne kundekort</string>
 
-    <string name="cardIdFormat">%1$s: %2$s</string>
-    <string name="storeNameAndNoteFormat" translatable="false">%1$s - %2$s</string>
-
     <string name="importExport">Import/eksport</string>
-    <string name="importName">Importer</string>
     <string name="exportName">Eksporter</string>
     <string name="importExportHelp">Sikkerhetskopiering av data lar deg flytte kortene til en annen enhet.</string>
     <string name="importedFrom">Importert fra: %1$s</string>
     <string name="exportedTo">Exportert til: %1$s</string>
-    <string name="fileMissing">Fil mangler: %1$s</string>
     <string name="importSuccessfulTitle">Importert</string>
     <string name="importFailedTitle">Kunne ikke importere</string>
     <string name="importFailed">Klarte ikke å importere: %1$s</string>
@@ -67,9 +59,6 @@
     <string name="importOptionApplicationTitle">Brukt eksternt program</string>
     <string name="importOptionApplicationExplanation">Bruk eksternt program som Nextcloud, eller din favorittfilbehandler til å åpne ei fil.</string>
     <string name="importOptionApplicationButton">Bruk eksternt program</string>
-    <string name="importOptionFixedTitle">Importer fra eksporteringsområde</string>
-    <string name="importOptionFixedExplanation">Importer fra området i filsystemet eksporter skrives til.</string>
-    <string name="importOptionFixedButton">Bruk eksporteringsplassering</string>
 
     <string name="about">About</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -11,7 +11,6 @@
     <string name="storeName">Winkel</string>
     <string name="note">Aantekening</string>
     <string name="cardId">Kaartnummer</string>
-    <string name="barcodeType">Soort barcode</string>
     <string name="barcodeNoBarcode">Deze kaart heeft geen barcode</string>
 
     <string name="cancel">Annuleren</string>
@@ -30,11 +29,9 @@
     <string name="copy_to_clipboard">Kaartnummer kopiëren naar klembord</string>
     <string name="share">Delen</string>
     <string name="sendLabel">Versturen&#8230;</string>
-    <string name="addedShortcut">Toegevoegd aan startscherm</string>
 
     <string name="editCardTitle">Klantenkaart bewerken</string>
     <string name="addCardTitle">Klantenkaart toevoegen</string>
-    <string name="viewCardTitle">Klantenkaart tonen</string>
     <string name="scanCardBarcode">Scan de barcode van de kaart</string>
     <string name="cardShortcut">Kaartsnelkoppeling</string>
     <string name="noCardsMessage">Je hebt nog geen kaarten toegevoegd.</string>
@@ -46,14 +43,11 @@
     <string name="noCardExistsError">De klantenkaart kan niet worden opgevraagd</string>
     <string name="failedParsingImportUriError">Kan de import-uri niet verwerken</string>
 
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Importeren/Exporteren</string>
-    <string name="importName">Importeren</string>
     <string name="exportName">Exporteren</string>
     <string name="importExportHelp">Door de gegevens te back-uppen kun je je kaarten overzetten naar een ander apparaat.</string>
     <string name="importedFrom">Geïmporteerd uit: %1$s</string>
     <string name="exportedTo">Geëxporteerd naar: %1$s</string>
-    <string name="fileMissing">Bestand ontbreekt: %1$s</string>
     <string name="importSuccessfulTitle">Importeren voltooid</string>
     <string name="importFailedTitle">Importeren mislukt</string>
     <string name="importFailed">Het importeren is mislukt: %1$s</string>
@@ -70,9 +64,6 @@
     <string name="importOptionApplicationTitle">Externe app gebruiken</string>
     <string name="importOptionApplicationExplanation">Open een bestand middels een externe app, zoals Dropbox, Google Drive of je favoriete bestandsbeheerder.</string>
     <string name="importOptionApplicationButton">Externe app gebruiken</string>
-    <string name="importOptionFixedTitle">Importeren uit exportlocatie</string>
-    <string name="importOptionFixedExplanation">Importeer uit dezelfde locatie op het bestandssysteem waar tijdens het exporteren naar weggeschreven is.</string>
-    <string name="importOptionFixedButton">Exportlocatie gebruiken</string>
 
     <string name="about">Over</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -11,7 +11,6 @@
     <string name="storeName">Sklep</string>
     <string name="note">Notatka</string>
     <string name="cardId">Identyfikator karty</string>
-    <string name="barcodeType">Typ kodu kreskowego</string>
     <string name="barcodeNoBarcode">Ta karta nie ma kodu kreskowego</string>
 
     <string name="cancel">Anuluj</string>
@@ -30,11 +29,9 @@
     <string name="copy_to_clipboard">Skopiuj identyfikator do schowka</string>
     <string name="share">Udostępnij</string>
     <string name="sendLabel">Wyślij&#8230;</string>
-    <string name="addedShortcut">Dodano do ekranu głównego</string>
 
     <string name="editCardTitle">Edytuj kartę lojalnościową</string>
     <string name="addCardTitle">Dodaj kartę lojalnościową</string>
-    <string name="viewCardTitle">Pokaż kartę lojalnościową</string>
     <string name="scanCardBarcode">Zeskanuj kod kreskowy karty lojalnościowej</string>
     <string name="cardShortcut">Skrót karty</string>
     <string name="noCardsMessage">Nie ma kart, należy dodać pierwszą</string>
@@ -46,14 +43,11 @@
     <string name="noCardExistsError">Nie można wyszukać karty lojalnościowej</string>
     <string name="failedParsingImportUriError">Nie można przeanalizować identyfikatora importu URI</string>
 
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Importuj/Eksportuj</string>
-    <string name="importName">Importuj</string>
     <string name="exportName">Eksportuj</string>
     <string name="importExportHelp">Zarchiwizowane dane umożliwiają przeniesienie kart na inne urządzenie.</string>
     <string name="importedFrom">Zaimportowano z: %1$s</string>
     <string name="exportedTo">Wyeksportowano do: %1$s</string>
-    <string name="fileMissing">Brak pliku: %1$s</string>
     <string name="importSuccessfulTitle">Zaimportowano pomyślnie</string>
     <string name="importFailedTitle">Import nie powiódł się</string>
     <string name="importFailed">Nie udało się zaimportować: %1$s</string>
@@ -70,9 +64,6 @@
     <string name="importOptionApplicationTitle">Użyj zewnętrznej aplikacji</string>
     <string name="importOptionApplicationExplanation">Użyj zewnętrznej aplikacji jak Dropbox, Google Drive, bądź ulubiony menedżer plików, aby otworzyć plik.</string>
     <string name="importOptionApplicationButton">Użyj zewnętrznej aplikacji</string>
-    <string name="importOptionFixedTitle">Importuj z lokalizacji eksportowania</string>
-    <string name="importOptionFixedExplanation">Importuj z tej samej lokalizacji w systemie plików, do którego zapisano przy eksporcie.</string>
-    <string name="importOptionFixedButton">Użyj lokalizacji eksportu</string>
 
     <string name="about">O aplikacji</string>
     <string name="app_copyright_fmt">© 2016 — <xliff:g>%d</xliff:g> Branden Archer.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -11,7 +11,6 @@
     <string name="storeName">Магазин</string>
     <string name="note">Примечание</string>
     <string name="cardId">Номер карты</string>
-    <string name="barcodeType">Тип штрих-кода</string>
     <string name="barcodeNoBarcode">Эта карта без штрихкода</string>
 
     <string name="cancel">Отменить</string>
@@ -30,11 +29,9 @@
     <string name="copy_to_clipboard">Скопировать номер карты в буфер обмена</string>
     <string name="share">Переслать</string>
     <string name="sendLabel">Отправить&#8230;</string>
-    <string name="addedShortcut">Карта добавлена на главный экран.</string>
 
     <string name="editCardTitle">Редактировать карту</string>
     <string name="addCardTitle">Добавить карту</string>
-    <string name="viewCardTitle">Посмотреть карту</string>
     <string name="scanCardBarcode">Отсканируйте штрих-код</string>
     <string name="cardShortcut">Ярлык карты</string>
     <string name="noCardsMessage">Карт нет, добавьте одну для начала</string>
@@ -46,14 +43,11 @@
     <string name="noCardExistsError">Карта не найдена</string>
     <string name="failedParsingImportUriError">Не удалось разобрать импортируемый URI</string>
 
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Импорт/Экспорт</string>
-    <string name="importName">Импорт</string>
     <string name="exportName">Экспорт</string>
     <string name="importExportHelp">Сохранение карт позволяет перенести их на другое устройство.</string>
     <string name="importedFrom">Импортировано из: %1$s</string>
     <string name="exportedTo">Экспортировано в: %1$s</string>
-    <string name="fileMissing">Файл не найден: %1$s</string>
     <string name="importSuccessfulTitle">Успешный импорт</string>
     <string name="importFailedTitle">Импорт не удался</string>
     <string name="importFailed">Не удалось импортировать: %1$s</string>
@@ -70,9 +64,6 @@
     <string name="importOptionApplicationTitle">Использование другого приложения</string>
     <string name="importOptionApplicationExplanation">Использовать другое приложение такое как Dropbox, Google Drive, или ваш любимый файловый менеджер чтобы открыть файл.</string>
     <string name="importOptionApplicationButton">Использовать другое приложение</string>
-    <string name="importOptionFixedTitle">Импорт из файла экспорта</string>
-    <string name="importOptionFixedExplanation">Импорт из того же файла, куда сохраняется экспорт.</string>
-    <string name="importOptionFixedButton">Использовать файл экспорта</string>
 
     <string name="about">О программе</string>
     <string name="app_copyright_fmt">Все права защищены 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -8,7 +8,6 @@
     <string name="storeName">Obchod</string>
     <string name="note">Poznámka</string>
     <string name="cardId">ID karty</string>
-    <string name="barcodeType">Typ čiarového kódu</string>
     <string name="cancel">Zrušiť</string>
     <string name="save">Uložiť</string>
     <string name="capture">Zosnímať kartu</string>
@@ -24,11 +23,9 @@
     <string name="ok">Áno</string>
     <string name="copy_to_clipboard">Kopírovať ID do schránky</string>
     <string name="sendLabel">Odoslať&#8230;</string>
-    <string name="addedShortcut">Pridané na domovskú obrazovku</string>
 
     <string name="editCardTitle">Upraviť kartu</string>
     <string name="addCardTitle">Pridať kartu</string>
-    <string name="viewCardTitle">Zobraziť kartu</string>
     <string name="scanCardBarcode">Zosnímajte čiarový kód na karte</string>
     <string name="cardShortcut">Skratka</string>
     <string name="noCardsMessage">Nie sú uložené žiadne karty, vložte prvú</string>
@@ -38,14 +35,11 @@
     <string name="noStoreError">Nebol zadaný obchod</string>
     <string name="noCardIdError">Nebolo zadané ID karty</string>
     <string name="noCardExistsError">Nie je možné vyhľadať vernostnú kartu</string>
-    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Import/Export</string>
-    <string name="importName">Import</string>
     <string name="exportName">Export</string>
     <string name="importExportHelp">Zálohovanie dát Vám umožní presunúť Vaše uložené karty na iné zariadenie.</string>
     <string name="importedFrom">Importované z: %1$s</string>
     <string name="exportedTo">Exportované do: %1$s</string>
-    <string name="fileMissing">Chýbajúci súbor: %1$s</string>
     <string name="importSuccessfulTitle">Import bol úspešný</string>
     <string name="importFailedTitle">Import zlyhal</string>
     <string name="importFailed">Zlyhal import: %1$s</string>
@@ -62,9 +56,6 @@
     <string name="importOptionApplicationTitle">Použite externú aplikáciu</string>
     <string name="importOptionApplicationExplanation">Na otvorenie súboru použite externú aplikáciu, ako Dropbox, Disk Google, alebo Vášho obľúbeného správcu súborov.</string>
     <string name="importOptionApplicationButton">Použiť externú aplikáciu</string>
-    <string name="importOptionFixedTitle">Importujte z exportovacieho umiestnenia.</string>
-    <string name="importOptionFixedExplanation">Importujte z rovnakého umiestnenia v súborovom systéme, na ktorý je zapisovaný export.</string>
-    <string name="importOptionFixedButton">Použite exportovacie umiestnenie</string>
 
     <string name="about">O aplikácii</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -8,7 +8,6 @@
     <string name="storeName">Shrani</string>
     <string name="note">Zabeležka</string>
     <string name="cardId">Št. kartice</string>
-    <string name="barcodeType">Vrsta črne kode</string>
     <string name="cancel">Prekliči</string>
     <string name="save">Shrani</string>
     <string name="capture">Slikaj kartico</string>
@@ -24,11 +23,9 @@
     <string name="ok">Vredu</string>
     <string name="copy_to_clipboard">Kopirajte številko kartice</string>
     <string name="sendLabel">Pošlji#8230;</string>
-    <string name="addedShortcut">Dodajte na domači zaslon</string>
 
     <string name="editCardTitle">Uredi kartico zvestobe</string>
     <string name="addCardTitle">Dodaj kartico zvestobe</string>
-    <string name="viewCardTitle">Prikaži kartico zvestobe</string>
     <string name="scanCardBarcode">Skeniraj črtno kodo</string>
     <string name="cardShortcut">Bližnjica do kartice</string>
     <string name="noCardsMessage">Trenutno ni na voljo nobene kartice. Najprej jih je potrebno dodati.</string>
@@ -38,14 +35,11 @@
     <string name="noStoreError">Ime trgovine ni bilo vnešeno</string>
     <string name="noCardIdError">Številka kartice ni bila vnešena</string>
     <string name="noCardExistsError">Te kartice zvestobe ni bilo moč najti</string>
-    <string name="cardIdFormat">%1$s:%2$s</string>
     <string name="importExport">Uvozi/izvozi</string>
-    <string name="importName">Uvozi</string>
     <string name="exportName">Izvozi</string>
     <string name="importExportHelp">Varnostna kopija omogoča varen prenos kartic na druge telefonske naprave.</string>
     <string name="importedFrom">Uvoženo iz: %1$s</string>
     <string name="exportedTo">Izvoženo v:%1$s</string>
-    <string name="fileMissing">Manjkajoča datoteka: %1$s</string>
     <string name="importSuccessfulTitle">Uvoz je bil uspešen</string>
     <string name="importFailedTitle">Uvoz ni uspel</string>
     <string name="importFailed">Napaka pri uvozu: %1$s</string>
@@ -62,9 +56,6 @@
     <string name="importOptionApplicationTitle">Uporabi zunanjo aplikacijo</string>
     <string name="importOptionApplicationExplanation">Uporabi zunanjo aplikacijo, kot npr. Dropbox, Google Drive ali ostale upravljalnike datotek, za odpiranje datoteko.</string>
     <string name="importOptionApplicationButton">Uporabi zunanjo aplikacijo</string>
-    <string name="importOptionFixedTitle">Uvozi iz zunanje aplikacije</string>
-    <string name="importOptionFixedExplanation">Uvozi iz iste lokacije, ki je namenjena izvozu</string>
-    <string name="importOptionFixedButton">Uporabi lokacijo izvoza</string>
 
     <string name="about">Več o aplikaciji</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,16 +65,13 @@
     <string name="importing">Importing&#8230;</string>
     <string name="exporting">Exporting&#8230;</string>
     <string name="noExternalStoragePermissionError">Unable to import or export cards without the external storage permission</string>
-    <string name="exportOptionExplanation">Data is written to the top directory in external storage.</string>
+    <string name="exportOptionExplanation">Data will be written to a location of your choice.</string>
     <string name="importOptionFilesystemTitle">Import from filesystem</string>
     <string name="importOptionFilesystemExplanation">Choose a specific file from the filesystem.</string>
     <string name="importOptionFilesystemButton">From filesystem</string>
     <string name="importOptionApplicationTitle">Use external application</string>
     <string name="importOptionApplicationExplanation">Use an external application like Dropbox, Google Drive, or your favorite file manager to open a file.</string>
     <string name="importOptionApplicationButton">Use external application</string>
-    <string name="importOptionFixedTitle">Import from export location</string>
-    <string name="importOptionFixedExplanation">Import from the same location on the filesystem that is written to on export.</string>
-    <string name="importOptionFixedButton">Use export location</string>
 
     <string name="about">About</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,6 @@
     <string name="storeName">Store</string>
     <string name="note">Note</string>
     <string name="cardId">Card ID</string>
-    <string name="barcodeType">Barcode Type</string>
     <string name="barcodeNoBarcode">This card has no barcode</string>
 
     <string name="cancel">Cancel</string>
@@ -30,11 +29,9 @@
     <string name="copy_to_clipboard">Copy ID to clipboard</string>
     <string name="share">Share</string>
     <string name="sendLabel">Send&#8230;</string>
-    <string name="addedShortcut">Added to Home Screen</string>
 
     <string name="editCardTitle">Edit Loyalty Card</string>
     <string name="addCardTitle">Add Loyalty Card</string>
-    <string name="viewCardTitle">View Loyalty Card</string>
     <string name="scanCardBarcode">Scan Card\'s Barcode</string>
     <string name="cardShortcut">Card Shortcut</string>
     <string name="noCardsMessage">There are no cards, add one first</string>
@@ -46,16 +43,11 @@
     <string name="noCardExistsError">Could not lookup loyalty card</string>
     <string name="failedParsingImportUriError">Could not parse the import URI</string>
 
-    <string name="cardIdFormat">%1$s: %2$s</string>
-    <string name="storeNameAndNoteFormat" translatable="false">%1$s - %2$s</string>
-
     <string name="importExport">Import/Export</string>
-    <string name="importName">Import</string>
     <string name="exportName">Export</string>
     <string name="importExportHelp">Backed up data can allow you to move your cards to another device.</string>
     <string name="importedFrom">Imported from: %1$s</string>
     <string name="exportedTo">Exported to: %1$s</string>
-    <string name="fileMissing">File missing: %1$s</string>
     <string name="importSuccessfulTitle">Import successful</string>
     <string name="importFailedTitle">Import failed</string>
     <string name="importFailed">Failed to import: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="storeName">Store</string>
     <string name="note">Note</string>
     <string name="cardId">Card ID</string>
+    <string name="barcodeType">Barcode type</string>
     <string name="barcodeNoBarcode">This card has no barcode</string>
 
     <string name="cancel">Cancel</string>
@@ -29,7 +30,7 @@
     <string name="copy_to_clipboard">Copy ID to clipboard</string>
     <string name="share">Share</string>
     <string name="sendLabel">Send&#8230;</string>
-
+    <string name="addedShortcut">Added shortcut</string>
     <string name="editCardTitle">Edit Loyalty Card</string>
     <string name="addCardTitle">Add Loyalty Card</string>
     <string name="scanCardBarcode">Scan Card\'s Barcode</string>
@@ -42,7 +43,7 @@
     <string name="noCardIdError">No Card ID entered</string>
     <string name="noCardExistsError">Could not lookup loyalty card</string>
     <string name="failedParsingImportUriError">Could not parse the import URI</string>
-
+    <string name="cardIdFormat">%1$s: %2$s</string>
     <string name="importExport">Import/Export</string>
     <string name="exportName">Export</string>
     <string name="importExportHelp">Backed up data can allow you to move your cards to another device.</string>

--- a/app/src/test/java/protect/card_locker/ImportExportActivityTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportActivityTest.java
@@ -84,12 +84,6 @@ public class ImportExportActivityTest
             checkVisibility(activity, View.GONE, R.id.dividerImportApplication,
                     R.id.importOptionApplicationTitle, R.id.importOptionApplicationExplanation,
                     R.id.importOptionApplicationButton);
-
-            // Import from file system should always be present
-
-            checkVisibility(activity, View.VISIBLE, R.id.dividerImportFixed,
-                    R.id.importOptionFixedTitle, R.id.importOptionFixedExplanation,
-                    R.id.importOptionFixedButton);
         }
     }
 
@@ -115,12 +109,6 @@ public class ImportExportActivityTest
             checkVisibility(activity, View.GONE, R.id.dividerImportFilesystem,
                     R.id.importOptionFilesystemTitle, R.id.importOptionFilesystemExplanation,
                     R.id.importOptionFilesystemButton);
-
-            // Import from file system should always be present
-
-            checkVisibility(activity, View.VISIBLE, R.id.dividerImportFixed,
-                    R.id.importOptionFixedTitle, R.id.importOptionFixedExplanation,
-                    R.id.importOptionFixedButton);
         }
     }
 
@@ -139,9 +127,5 @@ public class ImportExportActivityTest
         checkVisibility(activity, View.VISIBLE, R.id.dividerImportFilesystem,
                 R.id.importOptionFilesystemTitle, R.id.importOptionFilesystemExplanation,
                 R.id.importOptionFilesystemButton);
-
-        checkVisibility(activity, View.VISIBLE, R.id.dividerImportFixed,
-                R.id.importOptionFixedTitle, R.id.importOptionFixedExplanation,
-                R.id.importOptionFixedButton);
     }
 }

--- a/app/src/test/java/protect/card_locker/ImportExportTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportTest.java
@@ -3,6 +3,7 @@ package protect.card_locker;
 import android.app.Activity;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.net.Uri;
 import android.os.Environment;
 
 import com.google.zxing.BarcodeFormat;
@@ -20,9 +21,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 
@@ -245,7 +248,8 @@ public class ImportExportTest
             TestTaskCompleteListener listener = new TestTaskCompleteListener();
 
             // Export to the file
-            ImportExportTask task = new ImportExportTask(activity, format, exportFile, listener);
+            FileOutputStream fileOutputStream = new FileOutputStream(exportFile);
+            ImportExportTask task = new ImportExportTask(activity, format, fileOutputStream, listener);
             task.execute();
 
             // Actually run the task to completion


### PR DESCRIPTION
Should hopefully fix #349 by making the following changes:

- Don't export to a fixed location, open the filebrowser with the filename LoyaltyCardLocker.csv pre-filled
- Remove the import from default location button (as the default location selected by Android will be the same for both the import and export button)

This change assumes that every single Android device has a file manager available. I have yet to see an Android device where this is not the case.